### PR TITLE
Refine multus config file (masterplugin and always_use_default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ Go 1.5 users will need to set `GO15VENDOREXPERIMENT=1` to get vendored dependenc
 * `type` (string, required): "multus"
 * `kubeconfig` (string, optional): kubeconfig file for the out of cluster communication with kube-apiserver, Refer the doc
 * `delegates` (([]map,required): number of delegate details in the Multus, ignored in case kubeconfig is added.
-* `masterplugin` (bool,required): master plugin to report back the IP address and DNS to the container
 
 ## Usage with Kubernetes CRD/TPR based Network Objects
 
@@ -303,8 +302,7 @@ sriov-conf                   Network.v1.kubernetes-network.cni.cncf.io
     "kubeconfig": "/etc/kubernetes/node-kubeconfig.yaml",
     "delegates": [{
         "type": "weave-net",
-        "hairpinMode": true,
-        "masterplugin": true
+        "hairpinMode": true
     }]
 }
 ```
@@ -443,7 +441,6 @@ Given the following network configuration:
         },
         {
                 "type": "flannel",
-                "masterplugin": true,
                 "delegate": {
                         "isDefaultGateway": true
                 }
@@ -452,22 +449,6 @@ Given the following network configuration:
 }
 EOF
 
-```
-
-### Further options for CNI configuration file.
-
-One may also specify `always_use_default` as a boolean value. This option requires that you're using the CRD method (and therefore requires that you must also specify both the `kubeconfig` and the `delegates` option as well, or Multus will present an error message). In the case that `always_use_default` is true, the `delegates` network will always be applied, along with those specified in the annotations.
-
-For example, a valid configuration using the `always_use_default` may look like:
-
-```
-{
-  "name": "multus-cni-network",
-  "type": "multus",
-  "delegates": [{"type": "flannel", "isDefaultGateway": true, "masterplugin": true}],
-  "always_use_default": true,
-  "kubeconfig": "/etc/kubernetes/kubelet.conf"
-}
 ```
 
 ## Testing the Multus CNI ##

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,7 +10,7 @@ It is expected that aspects of your own setup will vary, at least in part, from 
 
 More specifically, these examples show:
 
-* Multus configured, using CNI a `.conf` file, with CRD support, specifying that we will use a "default network" with the `always_use_default` option set.
+* Multus configured, using CNI a `.conf` file, with CRD support, specifying that we will use a "default network".
 * A resource definition with a daemonset that places the `.conf` on each node in the cluster.
 * A CRD definining the "networks" @ `networks.kubernetes.cni.cncf.io` 
 * CRD objects containing the configuration for both Flannel & macvlan.

--- a/examples/cni-configuration.conf
+++ b/examples/cni-configuration.conf
@@ -4,12 +4,10 @@
   "delegates": [
     {
       "type": "flannel",
-      "masterplugin": true,
       "delegate": {
         "isDefaultGateway": true
       }
     }
   ],
-  "always_use_default": true,
   "kubeconfig": "/etc/kubernetes/kubelet.conf"
 }

--- a/examples/multus-with-flannel.yml
+++ b/examples/multus-with-flannel.yml
@@ -67,13 +67,11 @@ data:
       "delegates": [
         {
           "type": "flannel",
-          "masterplugin": true,
           "delegate": {
             "isDefaultGateway": true
           }
         }
       ],
-      "always_use_default": true,
       "kubeconfig": "/etc/kubernetes/kubelet.conf"
     }
   net-conf.json: |

--- a/types/types.go
+++ b/types/types.go
@@ -29,7 +29,6 @@ type NetConf struct {
 	CNIDir     string                   `json:"cniDir"`
 	Delegates  []map[string]interface{} `json:"delegates"`
 	Kubeconfig string                   `json:"kubeconfig"`
-	UseDefault bool                     `json:"always_use_default"`
 }
 
 type Network struct {


### PR DESCRIPTION
This fix removes 'masterplugin' and 'always_use_default' from multus config file. default network, defined in
/etc/cni/net.d/*conf should be master and this network should be used as default from network plumbing working group draft.