### PR TITLE
[minor] Updates kubernetes.v1 to k8s.v1 in the sample files

### DIFF
--- a/examples/npwg-demo-1/11_pod_case1.yml
+++ b/examples/npwg-demo-1/11_pod_case1.yml
@@ -4,7 +4,7 @@ kind: Pod
 metadata:
   name: pod-case-01
   annotations:
-    kubernetes.v1.cni.cncf.io/networks: macvlan-conf-1
+    k8s.v1.cni.cncf.io/networks: macvlan-conf-1
 spec:
   containers:
   - name: pod-case-01

--- a/examples/npwg-demo-1/12_pod_case2.yml
+++ b/examples/npwg-demo-1/12_pod_case2.yml
@@ -4,7 +4,7 @@ kind: Pod
 metadata:
   name: pod-case-02
   annotations:
-    kubernetes.v1.cni.cncf.io/networks: '[
+    k8s.v1.cni.cncf.io/networks: '[
             { "name": "macvlan-conf-2" },
             { "name": "vlan-conf-1-1",
               "namespace": "testns1",

--- a/examples/npwg-demo-1/13_pod_case3.yml
+++ b/examples/npwg-demo-1/13_pod_case3.yml
@@ -4,7 +4,7 @@ kind: Pod
 metadata:
   name: pod-case-03
   annotations:
-    kubernetes.v1.cni.cncf.io/networks: '[
+    k8s.v1.cni.cncf.io/networks: '[
             { "name": "macvlan-conf-3" },
             { "name": "macvlan-conf-4" },
             { "name": "flannel-2" }

--- a/examples/sample-pod.yml
+++ b/examples/sample-pod.yml
@@ -4,7 +4,7 @@ kind: Pod
 metadata:
   name: samplepod
   annotations:
-    kubernetes.v1.cni.cncf.io/networks: macvlan-conf
+    k8s.v1.cni.cncf.io/networks: macvlan-conf
 spec:
   containers:
   - name: samplepod


### PR DESCRIPTION
This is really a minor documentation fix, but, in tandem with the recent changes to the CRD name change, and the change from `s/kubernetes.v1/k8s.v1/` in the namespace, I went ahead and made the changes to the sample files as well.