### PR TITLE
Travis fixes after inClientConfig() changes

### DIFF
--- a/k8sclient/k8sclient_test.go
+++ b/k8sclient/k8sclient_test.go
@@ -227,7 +227,7 @@ var _ = Describe("k8sclient operations", func() {
 		fKubeClient.AddPod(fakePod)
 		fKubeClient.AddNetConfig(fakePod.ObjectMeta.Namespace, "net1", "{\"type\": \"mynet\"}")
 
-		delegates, err := GetK8sNetwork(args, "", fKubeClient, tmpDir)
+		delegates, err := GetK8sNetwork(fKubeClient, args, tmpDir)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(fKubeClient.PodCount).To(Equal(1))
 		Expect(fKubeClient.NetCount).To(Equal(1))


### PR DESCRIPTION
Noticed that my docs PR was failing, so I went and looked into it, looks like the number of params / order of params in the `GetK8sNetwork()` method was changed -- so I went ahead and changed it up in the test suite.

This should go in with version 3.0

originally failing build for reference: https://travis-ci.org/intel/multus-cni/builds/408897159