### PR TITLE
Add logging message for debug/error

### DIFF
--- a/k8sclient/k8sclient.go
+++ b/k8sclient/k8sclient.go
@@ -31,6 +31,7 @@ import (
 	"github.com/containernetworking/cni/libcni"
 	"github.com/containernetworking/cni/pkg/skel"
 	cnitypes "github.com/containernetworking/cni/pkg/types"
+	"github.com/intel/multus-cni/logging"
 	"github.com/intel/multus-cni/types"
 )
 
@@ -67,6 +68,7 @@ func (d *defaultKubeClient) UpdatePodStatus(pod *v1.Pod) (*v1.Pod, error) {
 }
 
 func setKubeClientInfo(c *clientInfo, client KubeClient, k8sArgs *types.K8sArgs) {
+	logging.Debugf("setKubeClientInfo: %v, %v, %v", c, client, k8sArgs)
 	c.Client = client
 	c.Podnamespace = string(k8sArgs.K8S_POD_NAMESPACE)
 	c.Podname = string(k8sArgs.K8S_POD_NAME)
@@ -74,9 +76,10 @@ func setKubeClientInfo(c *clientInfo, client KubeClient, k8sArgs *types.K8sArgs)
 
 func SetNetworkStatus(k *clientInfo, netStatus []*types.NetworkStatus) error {
 
+	logging.Debugf("SetNetworkStatus: %v, %v", k, netStatus)
 	pod, err := k.Client.GetPod(k.Podnamespace, k.Podname)
 	if err != nil {
-		return fmt.Errorf("SetNetworkStatus: failed to query the pod %v in out of cluster comm: %v", k.Podname, err)
+		return logging.Errorf("SetNetworkStatus: failed to query the pod %v in out of cluster comm: %v", k.Podname, err)
 	}
 
 	var ns string
@@ -85,7 +88,7 @@ func SetNetworkStatus(k *clientInfo, netStatus []*types.NetworkStatus) error {
 		for _, nets := range netStatus {
 			data, err := json.MarshalIndent(nets, "", "    ")
 			if err != nil {
-				return fmt.Errorf("SetNetworkStatus: error with Marshal Indent: %v", err)
+				return logging.Errorf("SetNetworkStatus: error with Marshal Indent: %v", err)
 			}
 			networkStatus = append(networkStatus, string(data))
 		}
@@ -94,13 +97,14 @@ func SetNetworkStatus(k *clientInfo, netStatus []*types.NetworkStatus) error {
 	}
 	_, err = setPodNetworkAnnotation(k.Client, k.Podnamespace, pod, ns)
 	if err != nil {
-		return fmt.Errorf("SetNetworkStatus: failed to update the pod %v in out of cluster comm: %v", k.Podname, err)
+		return logging.Errorf("SetNetworkStatus: failed to update the pod %v in out of cluster comm: %v", k.Podname, err)
 	}
 
 	return nil
 }
 
 func setPodNetworkAnnotation(client KubeClient, namespace string, pod *v1.Pod, networkstatus string) (*v1.Pod, error) {
+	logging.Debugf("setPodNetworkAnnotation: %v, %s, %v, %s", client, namespace, pod, networkstatus)
 	//if pod annotations is empty, make sure it allocatable
 	if len(pod.Annotations) == 0 {
 		pod.Annotations = make(map[string]string)
@@ -122,7 +126,7 @@ func setPodNetworkAnnotation(client KubeClient, namespace string, pod *v1.Pod, n
 		pod, err = client.UpdatePodStatus(pod)
 		return err
 	}); resultErr != nil {
-		return nil, fmt.Errorf("status update failed for pod %s/%s: %v", pod.Namespace, pod.Name, resultErr)
+		return nil, logging.Errorf("status update failed for pod %s/%s: %v", pod.Namespace, pod.Name, resultErr)
 	}
 	return pod, nil
 }
@@ -130,9 +134,10 @@ func setPodNetworkAnnotation(client KubeClient, namespace string, pod *v1.Pod, n
 func getPodNetworkAnnotation(client KubeClient, k8sArgs *types.K8sArgs) (string, string, error) {
 	var err error
 
+	logging.Debugf("getPodNetworkAnnotation: %v, %v", client, k8sArgs)
 	pod, err := client.GetPod(string(k8sArgs.K8S_POD_NAMESPACE), string(k8sArgs.K8S_POD_NAME))
 	if err != nil {
-		return "", "", fmt.Errorf("getPodNetworkAnnotation: failed to query the pod %v in out of cluster comm: %v", string(k8sArgs.K8S_POD_NAME), err)
+		return "", "", logging.Errorf("getPodNetworkAnnotation: failed to query the pod %v in out of cluster comm: %v", string(k8sArgs.K8S_POD_NAME), err)
 	}
 
 	return pod.Annotations["k8s.v1.cni.cncf.io/networks"], pod.ObjectMeta.Namespace, nil
@@ -143,6 +148,7 @@ func parsePodNetworkObjectName(podnetwork string) (string, string, string, error
 	var netIfName string
 	var networkName string
 
+	logging.Debugf("parsePodNetworkObjectName: %s", podnetwork)
 	slashItems := strings.Split(podnetwork, "/")
 	if len(slashItems) == 2 {
 		netNsName = strings.TrimSpace(slashItems[0])
@@ -150,7 +156,7 @@ func parsePodNetworkObjectName(podnetwork string) (string, string, string, error
 	} else if len(slashItems) == 1 {
 		networkName = slashItems[0]
 	} else {
-		return "", "", "", fmt.Errorf("Invalid network object (failed at '/')")
+		return "", "", "", logging.Errorf("Invalid network object (failed at '/')")
 	}
 
 	atItems := strings.Split(networkName, "@")
@@ -158,7 +164,7 @@ func parsePodNetworkObjectName(podnetwork string) (string, string, string, error
 	if len(atItems) == 2 {
 		netIfName = strings.TrimSpace(atItems[1])
 	} else if len(atItems) != 1 {
-		return "", "", "", fmt.Errorf("Invalid network object (failed at '@')")
+		return "", "", "", logging.Errorf("Invalid network object (failed at '@')")
 	}
 
 	// Check and see if each item matches the specification for valid attachment name.
@@ -170,23 +176,25 @@ func parsePodNetworkObjectName(podnetwork string) (string, string, string, error
 	for i := range allItems {
 		matched, _ := regexp.MatchString("^[a-z0-9]([-a-z0-9]*[a-z0-9])?$", allItems[i])
 		if !matched && len([]rune(allItems[i])) > 0 {
-			return "", "", "", fmt.Errorf(fmt.Sprintf("Failed to parse: one or more items did not match comma-delimited format (must consist of lower case alphanumeric characters). Must start and end with an alphanumeric character), mismatch @ '%v'", allItems[i]))
+			return "", "", "", logging.Errorf(fmt.Sprintf("Failed to parse: one or more items did not match comma-delimited format (must consist of lower case alphanumeric characters). Must start and end with an alphanumeric character), mismatch @ '%v'", allItems[i]))
 		}
 	}
 
+	logging.Debugf("parsePodNetworkObjectName: parsed: %s, %s, %s", netNsName, networkName, netIfName)
 	return netNsName, networkName, netIfName, nil
 }
 
 func parsePodNetworkAnnotation(podNetworks, defaultNamespace string) ([]*types.NetworkSelectionElement, error) {
 	var networks []*types.NetworkSelectionElement
 
+	logging.Debugf("parsePodNetworkAnnotation: %s, %s", podNetworks, defaultNamespace)
 	if podNetworks == "" {
-		return nil, fmt.Errorf("parsePodNetworkAnnotation: pod annotation not having \"network\" as key, refer Multus README.md for the usage guide")
+		return nil, logging.Errorf("parsePodNetworkAnnotation: pod annotation not having \"network\" as key, refer Multus README.md for the usage guide")
 	}
 
 	if strings.IndexAny(podNetworks, "[{\"") >= 0 {
 		if err := json.Unmarshal([]byte(podNetworks), &networks); err != nil {
-			return nil, fmt.Errorf("parsePodNetworkAnnotation: failed to parse pod Network Attachment Selection Annotation JSON format: %v", err)
+			return nil, logging.Errorf("parsePodNetworkAnnotation: failed to parse pod Network Attachment Selection Annotation JSON format: %v", err)
 		}
 	} else {
 		// Comma-delimited list of network attachment object names
@@ -197,7 +205,7 @@ func parsePodNetworkAnnotation(podNetworks, defaultNamespace string) ([]*types.N
 			// Parse network name (i.e. <namespace>/<network name>@<ifname>)
 			netNsName, networkName, netIfName, err := parsePodNetworkObjectName(item)
 			if err != nil {
-				return nil, fmt.Errorf("parsePodNetworkAnnotation: %v", err)
+				return nil, logging.Errorf("parsePodNetworkAnnotation: %v", err)
 			}
 
 			networks = append(networks, &types.NetworkSelectionElement{
@@ -218,6 +226,7 @@ func parsePodNetworkAnnotation(podNetworks, defaultNamespace string) ([]*types.N
 }
 
 func getCNIConfigFromFile(name string, confdir string) ([]byte, error) {
+	logging.Debugf("getCNIConfigFromFile: %s, %s", name, confdir)
 
 	// In the absence of valid keys in a Spec, the runtime (or
 	// meta-plugin) should load and execute a CNI .configlist
@@ -228,9 +237,9 @@ func getCNIConfigFromFile(name string, confdir string) ([]byte, error) {
 	files, err := libcni.ConfFiles(confdir, []string{".conf", ".json", ".conflist"})
 	switch {
 	case err != nil:
-		return nil, fmt.Errorf("No networks found in %s", confdir)
+		return nil, logging.Errorf("No networks found in %s", confdir)
 	case len(files) == 0:
-		return nil, fmt.Errorf("No networks found in %s", confdir)
+		return nil, logging.Errorf("No networks found in %s", confdir)
 	}
 
 	for _, confFile := range files {
@@ -238,7 +247,7 @@ func getCNIConfigFromFile(name string, confdir string) ([]byte, error) {
 		if strings.HasSuffix(confFile, ".conflist") {
 			confList, err = libcni.ConfListFromFile(confFile)
 			if err != nil {
-				return nil, fmt.Errorf("Error loading CNI conflist file %s: %v", confFile, err)
+				return nil, logging.Errorf("Error loading CNI conflist file %s: %v", confFile, err)
 			}
 
 			if confList.Name == name {
@@ -248,21 +257,21 @@ func getCNIConfigFromFile(name string, confdir string) ([]byte, error) {
 		} else {
 			conf, err := libcni.ConfFromFile(confFile)
 			if err != nil {
-				return nil, fmt.Errorf("Error loading CNI config file %s: %v", confFile, err)
+				return nil, logging.Errorf("Error loading CNI config file %s: %v", confFile, err)
 			}
 
 			if conf.Network.Name == name {
 				// Ensure the config has a "type" so we know what plugin to run.
 				// Also catches the case where somebody put a conflist into a conf file.
 				if conf.Network.Type == "" {
-					return nil, fmt.Errorf("Error loading CNI config file %s: no 'type'; perhaps this is a .conflist?", confFile)
+					return nil, logging.Errorf("Error loading CNI config file %s: no 'type'; perhaps this is a .conflist?", confFile)
 				}
 				return conf.Bytes, nil
 			}
 		}
 	}
 
-	return nil, fmt.Errorf("no network available in the name %s in cni dir %s", name, confdir)
+	return nil, logging.Errorf("no network available in the name %s in cni dir %s", name, confdir)
 }
 
 // getCNIConfigFromSpec reads a CNI JSON configuration from the NetworkAttachmentDefinition
@@ -271,10 +280,11 @@ func getCNIConfigFromSpec(configData, netName string) ([]byte, error) {
 	var rawConfig map[string]interface{}
 	var err error
 
+	logging.Debugf("getCNIConfigFromSpec: %s, %s", configData, netName)
 	configBytes := []byte(configData)
 	err = json.Unmarshal(configBytes, &rawConfig)
 	if err != nil {
-		return nil, fmt.Errorf("getCNIConfigFromSpec: failed to unmarshal Spec.Config: %v", err)
+		return nil, logging.Errorf("getCNIConfigFromSpec: failed to unmarshal Spec.Config: %v", err)
 	}
 
 	// Inject network name if missing from Config for the thick plugin case
@@ -282,7 +292,7 @@ func getCNIConfigFromSpec(configData, netName string) ([]byte, error) {
 		rawConfig["name"] = netName
 		configBytes, err = json.Marshal(rawConfig)
 		if err != nil {
-			return nil, fmt.Errorf("getCNIConfigFromSpec: failed to re-marshal Spec.Config: %v", err)
+			return nil, logging.Errorf("getCNIConfigFromSpec: failed to re-marshal Spec.Config: %v", err)
 		}
 	}
 
@@ -293,6 +303,7 @@ func cniConfigFromNetworkResource(customResource *types.NetworkAttachmentDefinit
 	var config []byte
 	var err error
 
+	logging.Debugf("cniConfigFromNetworkResource: %v, %s", customResource, confdir)
 	emptySpec := types.NetworkAttachmentDefinitionSpec{}
 	if customResource.Spec == emptySpec {
 		// Network Spec empty; generate delegate from CNI JSON config
@@ -300,7 +311,7 @@ func cniConfigFromNetworkResource(customResource *types.NetworkAttachmentDefinit
 		// name as the custom resource
 		config, err = getCNIConfigFromFile(customResource.Metadata.Name, confdir)
 		if err != nil {
-			return nil, fmt.Errorf("cniConfigFromNetworkResource: err in getCNIConfigFromFile: %v", err)
+			return nil, logging.Errorf("cniConfigFromNetworkResource: err in getCNIConfigFromFile: %v", err)
 		}
 	} else {
 		// Config contains a standard JSON-encoded CNI configuration
@@ -308,7 +319,7 @@ func cniConfigFromNetworkResource(customResource *types.NetworkAttachmentDefinit
 		// execute.
 		config, err = getCNIConfigFromSpec(customResource.Spec.Config, customResource.Metadata.Name)
 		if err != nil {
-			return nil, fmt.Errorf("cniConfigFromNetworkResource: err in getCNIConfigFromSpec: %v", err)
+			return nil, logging.Errorf("cniConfigFromNetworkResource: err in getCNIConfigFromSpec: %v", err)
 		}
 	}
 
@@ -316,15 +327,16 @@ func cniConfigFromNetworkResource(customResource *types.NetworkAttachmentDefinit
 }
 
 func getKubernetesDelegate(client KubeClient, net *types.NetworkSelectionElement, confdir string) (*types.DelegateNetConf, error) {
+	logging.Debugf("getKubernetesDelegate: %v, %v, %s", client, net, confdir)
 	rawPath := fmt.Sprintf("/apis/k8s.cni.cncf.io/v1/namespaces/%s/network-attachment-definitions/%s", net.Namespace, net.Name)
 	netData, err := client.GetRawWithPath(rawPath)
 	if err != nil {
-		return nil, fmt.Errorf("getKubernetesDelegate: failed to get network resource, refer Multus README.md for the usage guide: %v", err)
+		return nil, logging.Errorf("getKubernetesDelegate: failed to get network resource, refer Multus README.md for the usage guide: %v", err)
 	}
 
 	customResource := &types.NetworkAttachmentDefinition{}
 	if err := json.Unmarshal(netData, customResource); err != nil {
-		return nil, fmt.Errorf("getKubernetesDelegate: failed to get the netplugin data: %v", err)
+		return nil, logging.Errorf("getKubernetesDelegate: failed to get the netplugin data: %v", err)
 	}
 
 	configBytes, err := cniConfigFromNetworkResource(customResource, confdir)
@@ -349,6 +361,7 @@ type KubeClient interface {
 func GetK8sArgs(args *skel.CmdArgs) (*types.K8sArgs, error) {
 	k8sArgs := &types.K8sArgs{}
 
+	logging.Debugf("GetK8sNetwork: %v", args)
 	err := cnitypes.LoadArgs(args.Args, k8sArgs)
 	if err != nil {
 		return nil, err
@@ -363,6 +376,7 @@ func TryLoadK8sDelegates(k8sArgs *types.K8sArgs, conf *types.NetConf, kubeClient
 	var err error
 	clientInfo := &clientInfo{}
 
+	logging.Debugf("TryLoadK8sDelegates: %v, %v, %v", k8sArgs, conf, kubeClient)
 	kubeClient, err = GetK8sClient(conf.Kubeconfig, kubeClient)
 	if err != nil {
 		return 0, nil, err
@@ -371,7 +385,7 @@ func TryLoadK8sDelegates(k8sArgs *types.K8sArgs, conf *types.NetConf, kubeClient
 	if kubeClient == nil {
 		if len(conf.Delegates) == 0 {
 			// No available kube client and no delegates, we can't do anything
-			return 0, nil, fmt.Errorf("must have either Kubernetes config or delegates, refer Multus README.md for the usage guide")
+			return 0, nil, logging.Errorf("must have either Kubernetes config or delegates, refer Multus README.md for the usage guide")
 		}
 		return 0, nil, nil
 	}
@@ -382,7 +396,7 @@ func TryLoadK8sDelegates(k8sArgs *types.K8sArgs, conf *types.NetConf, kubeClient
 		if _, ok := err.(*NoK8sNetworkError); ok {
 			return 0, clientInfo, nil
 		}
-		return 0, nil, fmt.Errorf("Multus: Err in getting k8s network from pod: %v", err)
+		return 0, nil, logging.Errorf("Multus: Err in getting k8s network from pod: %v", err)
 	}
 
 	if err = conf.AddDelegates(delegates); err != nil {
@@ -393,6 +407,7 @@ func TryLoadK8sDelegates(k8sArgs *types.K8sArgs, conf *types.NetConf, kubeClient
 }
 
 func GetK8sClient(kubeconfig string, kubeClient KubeClient) (KubeClient, error) {
+	logging.Debugf("GetK8sClient: %s, %v", kubeconfig, kubeClient)
 	// If we get a valid kubeClient (eg from testcases) just return that
 	// one.
 	if kubeClient != nil {
@@ -407,13 +422,13 @@ func GetK8sClient(kubeconfig string, kubeClient KubeClient) (KubeClient, error) 
 		// uses the current context in kubeconfig
 		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
 		if err != nil {
-			return nil, fmt.Errorf("GetK8sClient: failed to get context for the kubeconfig %v, refer Multus README.md for the usage guide: %v", kubeconfig, err)
+			return nil, logging.Errorf("GetK8sClient: failed to get context for the kubeconfig %v, refer Multus README.md for the usage guide: %v", kubeconfig, err)
 		}
 	} else if os.Getenv("KUBERNETES_SERVICE_HOST") != "" && os.Getenv("KUBERNETES_SERVICE_PORT") != "" {
 		// Try in-cluster config where multus might be running in a kubernetes pod
 		config, err = rest.InClusterConfig()
 		if err != nil {
-			return nil, fmt.Errorf("createK8sClient: failed to get context for in-cluster kube config, refer Multus README.md for the usage guide: %v", err)
+			return nil, logging.Errorf("createK8sClient: failed to get context for in-cluster kube config, refer Multus README.md for the usage guide: %v", err)
 		}
 	} else {
 		// No kubernetes config; assume we shouldn't talk to Kube at all
@@ -430,6 +445,7 @@ func GetK8sClient(kubeconfig string, kubeClient KubeClient) (KubeClient, error) 
 }
 
 func GetK8sNetwork(k8sclient KubeClient, k8sArgs *types.K8sArgs, confdir string) ([]*types.DelegateNetConf, error) {
+	logging.Debugf("GetK8sNetwork: %v, %v, %v", k8sclient, k8sArgs, confdir)
 
 	netAnnot, defaultNamespace, err := getPodNetworkAnnotation(k8sclient, k8sArgs)
 	if err != nil {
@@ -450,7 +466,7 @@ func GetK8sNetwork(k8sclient KubeClient, k8sArgs *types.K8sArgs, confdir string)
 	for _, net := range networks {
 		delegate, err := getKubernetesDelegate(k8sclient, net, confdir)
 		if err != nil {
-			return nil, fmt.Errorf("GetK8sNetwork: failed getting the delegate: %v", err)
+			return nil, logging.Errorf("GetK8sNetwork: failed getting the delegate: %v", err)
 		}
 		delegates = append(delegates, delegate)
 	}

--- a/logging/logging.go
+++ b/logging/logging.go
@@ -35,8 +35,9 @@ const (
 )
 
 var loggingStderr bool
-var loggingFp	*os.File
+var loggingFp *os.File
 var loggingLevel Level
+
 const defaultTimestampFormat = time.RFC3339
 
 func (l Level) String() string {
@@ -75,8 +76,9 @@ func Debugf(format string, a ...interface{}) {
 	Printf(DebugLevel, format, a...)
 }
 
-func Errorf(format string, a ...interface{}) {
+func Errorf(format string, a ...interface{}) error {
 	Printf(ErrorLevel, format, a...)
+	return fmt.Errorf(format, a...)
 }
 
 func Panicf(format string, a ...interface{}) {
@@ -86,7 +88,7 @@ func Panicf(format string, a ...interface{}) {
 	Printf(PanicLevel, "========= Stack trace output end ========")
 }
 
-func GetLoggingLevel (levelStr string) Level {
+func GetLoggingLevel(levelStr string) Level {
 	switch strings.ToLower(levelStr) {
 	case "debug":
 		return DebugLevel
@@ -99,18 +101,18 @@ func GetLoggingLevel (levelStr string) Level {
 	return UnknownLevel
 }
 
-func SetLogLevel (levelStr string) {
+func SetLogLevel(levelStr string) {
 	level := GetLoggingLevel(levelStr)
 	if level < MaxLevel {
 		loggingLevel = level
 	}
 }
 
-func SetLogStderr (enable bool) {
+func SetLogStderr(enable bool) {
 	loggingStderr = enable
 }
 
-func SetLogFile (filename string) {
+func SetLogFile(filename string) {
 	if filename == "" {
 		return
 	}

--- a/logging/logging_test.go
+++ b/logging/logging_test.go
@@ -17,8 +17,8 @@ package logging
 import (
 	"testing"
 
-        . "github.com/onsi/ginkgo"
-        . "github.com/onsi/gomega"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 )
 
 func TestLogging(t *testing.T) {

--- a/multus/multus.go
+++ b/multus/multus.go
@@ -38,6 +38,7 @@ import (
 )
 
 func saveScratchNetConf(containerID, dataDir string, netconf []byte) error {
+	logging.Debugf("saveScratchNetConf: %s, %s, %s", containerID, dataDir, string(netconf))
 	if err := os.MkdirAll(dataDir, 0700); err != nil {
 		return logging.Errorf("failed to create the multus data directory(%q): %v", dataDir, err)
 	}
@@ -53,6 +54,7 @@ func saveScratchNetConf(containerID, dataDir string, netconf []byte) error {
 }
 
 func consumeScratchNetConf(containerID, dataDir string) ([]byte, error) {
+	logging.Debugf("consumeScratchNetConf: %s, %s", containerID, dataDir)
 	path := filepath.Join(dataDir, containerID)
 	defer os.Remove(path)
 
@@ -60,6 +62,7 @@ func consumeScratchNetConf(containerID, dataDir string) ([]byte, error) {
 }
 
 func getIfname(delegate *types.DelegateNetConf, argif string, idx int) string {
+	logging.Debugf("getIfname: %v, %s, %d", delegate, argif, idx)
 	if delegate.IfnameRequest != "" {
 		return delegate.IfnameRequest
 	}
@@ -74,6 +77,7 @@ func getIfname(delegate *types.DelegateNetConf, argif string, idx int) string {
 }
 
 func saveDelegates(containerID, dataDir string, delegates []*types.DelegateNetConf) error {
+	logging.Debugf("saveDelegates: %s, %s, %v", containerID, dataDir, delegates)
 	delegatesBytes, err := json.Marshal(delegates)
 	if err != nil {
 		return logging.Errorf("error serializing delegate netconf: %v", err)
@@ -87,6 +91,7 @@ func saveDelegates(containerID, dataDir string, delegates []*types.DelegateNetCo
 }
 
 func validateIfName(nsname string, ifname string) error {
+	logging.Debugf("validateIfName: %s, %s", nsname, ifname)
 	podNs, err := ns.GetNS(nsname)
 	if err != nil {
 		return logging.Errorf("no netns: %v", err)
@@ -107,6 +112,7 @@ func validateIfName(nsname string, ifname string) error {
 }
 
 func conflistAdd(rt *libcni.RuntimeConf, rawnetconflist []byte, binDir string) (cnitypes.Result, error) {
+	logging.Debugf("conflistAdd: %v, %s, %s", rt, string(rawnetconflist), binDir)
 	// In part, adapted from K8s pkg/kubelet/dockershim/network/cni/cni.go
 	binDirs := []string{binDir}
 	cniNet := libcni.CNIConfig{Path: binDirs}
@@ -125,6 +131,7 @@ func conflistAdd(rt *libcni.RuntimeConf, rawnetconflist []byte, binDir string) (
 }
 
 func conflistDel(rt *libcni.RuntimeConf, rawnetconflist []byte, binDir string) error {
+	logging.Debugf("conflistDel: %v, %s, %s", rt, string(rawnetconflist), binDir)
 	// In part, adapted from K8s pkg/kubelet/dockershim/network/cni/cni.go
 	binDirs := []string{binDir}
 	cniNet := libcni.CNIConfig{Path: binDirs}

--- a/types/conf.go
+++ b/types/conf.go
@@ -17,7 +17,6 @@ package types
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"github.com/containernetworking/cni/libcni"
 	"github.com/containernetworking/cni/pkg/skel"
@@ -35,15 +34,16 @@ const (
 
 func LoadDelegateNetConfList(bytes []byte, delegateConf *DelegateNetConf) error {
 
+	logging.Debugf("LoadDelegateNetConfList: %v, %v", bytes, delegateConf)
 	if err := json.Unmarshal(bytes, &delegateConf.ConfList); err != nil {
-		return fmt.Errorf("err in unmarshalling delegate conflist: %v", err)
+		return logging.Errorf("err in unmarshalling delegate conflist: %v", err)
 	}
 
 	if delegateConf.ConfList.Plugins == nil {
-		return fmt.Errorf("delegate must have the 'type'or 'Plugin' field")
+		return logging.Errorf("delegate must have the 'type'or 'Plugin' field")
 	}
 	if delegateConf.ConfList.Plugins[0].Type == "" {
-		return fmt.Errorf("a plugin delegate must have the 'type' field")
+		return logging.Errorf("a plugin delegate must have the 'type' field")
 	}
 	delegateConf.ConfListPlugin = true
 	return nil
@@ -52,14 +52,15 @@ func LoadDelegateNetConfList(bytes []byte, delegateConf *DelegateNetConf) error 
 // Convert raw CNI JSON into a DelegateNetConf structure
 func LoadDelegateNetConf(bytes []byte, ifnameRequest string) (*DelegateNetConf, error) {
 	delegateConf := &DelegateNetConf{}
+	logging.Debugf("LoadDelegateNetConf: %v, %s", bytes, ifnameRequest)
 	if err := json.Unmarshal(bytes, &delegateConf.Conf); err != nil {
-		return nil, fmt.Errorf("error in LoadDelegateNetConf - unmarshalling delegate config: %v", err)
+		return nil, logging.Errorf("error in LoadDelegateNetConf - unmarshalling delegate config: %v", err)
 	}
 
 	// Do some minimal validation
 	if delegateConf.Conf.Type == "" {
 		if err := LoadDelegateNetConfList(bytes, delegateConf); err != nil {
-			return nil, fmt.Errorf("error in LoadDelegateNetConf: %v", err)
+			return nil, logging.Errorf("error in LoadDelegateNetConf: %v", err)
 		}
 	}
 
@@ -74,6 +75,7 @@ func LoadDelegateNetConf(bytes []byte, ifnameRequest string) (*DelegateNetConf, 
 
 func LoadCNIRuntimeConf(args *skel.CmdArgs, k8sArgs *K8sArgs, ifName string) (*libcni.RuntimeConf, error) {
 
+	logging.Debugf("LoadCNIRuntimeConf: %v, %v, %s", args, k8sArgs, ifName)
 	// In part, adapted from K8s pkg/kubelet/dockershim/network/cni/cni.go#buildCNIRuntimeConf
 	// Todo
 	// ingress, egress and bandwidth capability features as same as kubelet.
@@ -92,10 +94,12 @@ func LoadCNIRuntimeConf(args *skel.CmdArgs, k8sArgs *K8sArgs, ifName string) (*l
 }
 
 func LoadNetworkStatus(r types.Result, netName string, defaultNet bool) (*NetworkStatus, error) {
+	logging.Debugf("LoadNetworkStatus: %v, %s, %s", r, netName, defaultNet)
+
 	// Convert whatever the IPAM result was into the current Result type
 	result, err := current.NewResultFromResult(r)
 	if err != nil {
-		return nil, fmt.Errorf("error convert the type.Result to current.Result: %v", err)
+		return nil, logging.Errorf("error convert the type.Result to current.Result: %v", err)
 	}
 
 	netstatus := &NetworkStatus{}
@@ -128,8 +132,10 @@ func LoadNetworkStatus(r types.Result, netName string, defaultNet bool) (*Networ
 
 func LoadNetConf(bytes []byte) (*NetConf, error) {
 	netconf := &NetConf{}
+
+	logging.Debugf("LoadNetConf: %v", bytes)
 	if err := json.Unmarshal(bytes, netconf); err != nil {
-		return nil, fmt.Errorf("failed to load netconf: %v", err)
+		return nil, logging.Errorf("failed to load netconf: %v", err)
 	}
 
 	// Logging
@@ -144,16 +150,16 @@ func LoadNetConf(bytes []byte) (*NetConf, error) {
 	if netconf.RawPrevResult != nil {
 		resultBytes, err := json.Marshal(netconf.RawPrevResult)
 		if err != nil {
-			return nil, fmt.Errorf("could not serialize prevResult: %v", err)
+			return nil, logging.Errorf("could not serialize prevResult: %v", err)
 		}
 		res, err := version.NewResult(netconf.CNIVersion, resultBytes)
 		if err != nil {
-			return nil, fmt.Errorf("could not parse prevResult: %v", err)
+			return nil, logging.Errorf("could not parse prevResult: %v", err)
 		}
 		netconf.RawPrevResult = nil
 		netconf.PrevResult, err = current.NewResultFromResult(res)
 		if err != nil {
-			return nil, fmt.Errorf("could not convert result to current version: %v", err)
+			return nil, logging.Errorf("could not convert result to current version: %v", err)
 		}
 	}
 
@@ -164,7 +170,7 @@ func LoadNetConf(bytes []byte) (*NetConf, error) {
 	// the existing delegate list and all delegates executed in-order.
 
 	if len(netconf.RawDelegates) == 0 {
-		return nil, fmt.Errorf("at least one delegate must be specified")
+		return nil, logging.Errorf("at least one delegate must be specified")
 	}
 
 	if netconf.CNIDir == "" {
@@ -182,11 +188,11 @@ func LoadNetConf(bytes []byte) (*NetConf, error) {
 	for idx, rawConf := range netconf.RawDelegates {
 		bytes, err := json.Marshal(rawConf)
 		if err != nil {
-			return nil, fmt.Errorf("error marshalling delegate %d config: %v", idx, err)
+			return nil, logging.Errorf("error marshalling delegate %d config: %v", idx, err)
 		}
 		delegateConf, err := LoadDelegateNetConf(bytes, "")
 		if err != nil {
-			return nil, fmt.Errorf("failed to load delegate %d config: %v", idx, err)
+			return nil, logging.Errorf("failed to load delegate %d config: %v", idx, err)
 		}
 		netconf.Delegates = append(netconf.Delegates, delegateConf)
 	}
@@ -200,6 +206,7 @@ func LoadNetConf(bytes []byte) (*NetConf, error) {
 
 // AddDelegates appends the new delegates to the delegates list
 func (n *NetConf) AddDelegates(newDelegates []*DelegateNetConf) error {
+	logging.Debugf("AddDelegates: %v", newDelegates)
 	n.Delegates = append(n.Delegates, newDelegates...)
 	return nil
 }

--- a/types/conf.go
+++ b/types/conf.go
@@ -34,7 +34,7 @@ const (
 
 func LoadDelegateNetConfList(bytes []byte, delegateConf *DelegateNetConf) error {
 
-	logging.Debugf("LoadDelegateNetConfList: %v, %v", bytes, delegateConf)
+	logging.Debugf("LoadDelegateNetConfList: %s, %v", string(bytes), delegateConf)
 	if err := json.Unmarshal(bytes, &delegateConf.ConfList); err != nil {
 		return logging.Errorf("err in unmarshalling delegate conflist: %v", err)
 	}
@@ -52,7 +52,7 @@ func LoadDelegateNetConfList(bytes []byte, delegateConf *DelegateNetConf) error 
 // Convert raw CNI JSON into a DelegateNetConf structure
 func LoadDelegateNetConf(bytes []byte, ifnameRequest string) (*DelegateNetConf, error) {
 	delegateConf := &DelegateNetConf{}
-	logging.Debugf("LoadDelegateNetConf: %v, %s", bytes, ifnameRequest)
+	logging.Debugf("LoadDelegateNetConf: %s, %s", string(bytes), ifnameRequest)
 	if err := json.Unmarshal(bytes, &delegateConf.Conf); err != nil {
 		return nil, logging.Errorf("error in LoadDelegateNetConf - unmarshalling delegate config: %v", err)
 	}
@@ -133,7 +133,7 @@ func LoadNetworkStatus(r types.Result, netName string, defaultNet bool) (*Networ
 func LoadNetConf(bytes []byte) (*NetConf, error) {
 	netconf := &NetConf{}
 
-	logging.Debugf("LoadNetConf: %v", bytes)
+	logging.Debugf("LoadNetConf: %s", string(bytes))
 	if err := json.Unmarshal(bytes, netconf); err != nil {
 		return nil, logging.Errorf("failed to load netconf: %v", err)
 	}


### PR DESCRIPTION
This changes adds initial logging messages:debug and error. 

Error messages:
fmt.Errorf() is wrapped by logging.Errorf() hence all error message is also put to log file. 

Debug messages:
Added logging.Debugf() at the head of almost func, so we could track the code by logging message.