### PR TITLE
Fix glide.yaml

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -1,16 +1,18 @@
 package: github.com/intel/multus-cni
+ignore:
+- bytes
 import:
 - package: github.com/containernetworking/cni
   version: 07c1a6da47b7fbf8b357f4949ecce2113e598491
   subpackages:
-  - pkg/ip
-  - pkg/ipam
   - pkg/skel
   - pkg/types
   - pkg/version
 - package: github.com/containernetworking/plugins
   version: 2b8b1ac0af4568e928d96ccc5f47b075416eeabd
   subpackages:
+  - pkg/ip
+  - pkg/ipam
   - pkg/ns
 - package: github.com/onsi/ginkgo
   version: 7f8ab55aaf3b86885aa55b762e803744d1674700


### PR DESCRIPTION
This change fixes glide.yaml: track on cni's subpackage change and some error about bytes package. With this change, verified that 'glide up' works without any error.