### PR TITLE
Support 'mac' to specify MAC address for interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,7 +422,6 @@ spec:
           }
         },
         {
-          "name":"macchange",
           "type":"tuning"
         }]
 

--- a/README.md
+++ b/README.md
@@ -387,6 +387,48 @@ NAME                   READY     STATUS    RESTARTS   AGE
 multus-multi-net-poc   1/1       Running   0          30s
 ```
 
+#### Pod Annotation Parameters
+
+JSON formated network annotation in Pod can have several parameters as following:
+
+- namespace: Kubernetes namespace that the target network attach definition is defined in.
+- mac: MAC address (e.g "c2:11:22:33:44:66") for target network interface
+- interfaceRequest: interface name for target network interface
+
+Note: If you add `mac`, please add 'tuning' plugin into target network attach definition as CNI plugin chaining as following.
+
+```
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: macvlan with tuning
+spec:
+  config: '{
+      "cniVersion": "0.3.0",
+      "name": "chains",
+      "plugins": [ {
+        "type": "macvlan",
+        "master": "eth0",
+        "mode": "bridge",
+          "ipam": {
+            "type": "host-local",
+            "subnet": "192.168.1.0/24",
+            "rangeStart": "192.168.1.200",
+            "rangeEnd": "192.168.1.216",
+            "routes": [
+              { "dst": "0.0.0.0/0" }
+            ],
+            "gateway": "192.168.1.1"
+          }
+        },
+        {
+          "name":"macchange",
+          "type":"tuning"
+        }]
+
+  }'
+```
+
 ### Verifying Pod network interfaces
 
 1. Run `ifconfig` command in Pod:

--- a/k8sclient/k8sclient.go
+++ b/k8sclient/k8sclient.go
@@ -379,7 +379,7 @@ func getKubernetesDelegate(client KubeClient, net *types.NetworkSelectionElement
 		return nil, resourceMap, err
 	}
 
-	delegate, err := types.LoadDelegateNetConf(configBytes, net.InterfaceRequest, deviceID)
+	delegate, err := types.LoadDelegateNetConf(configBytes, net, deviceID)
 	if err != nil {
 		return nil, resourceMap, err
 	}

--- a/k8sclient/k8sclient.go
+++ b/k8sclient/k8sclient.go
@@ -536,7 +536,7 @@ func getDefaultNetDelegateCRD(client KubeClient, net string, confdir string) (*t
 		return nil, err
 	}
 
-	delegate, err := types.LoadDelegateNetConf(configBytes, "", "")
+	delegate, err := types.LoadDelegateNetConf(configBytes, nil, "")
 	if err != nil {
 		return nil, err
 	}
@@ -556,7 +556,7 @@ func getNetDelegate(client KubeClient, netname string, confdir string) (*types.D
 	var configBytes []byte
 	configBytes, err = getCNIConfigFromFile(netname, confdir)
 	if err == nil {
-		delegate, err := types.LoadDelegateNetConf(configBytes, "", "")
+		delegate, err := types.LoadDelegateNetConf(configBytes, nil, "")
 		if err != nil {
 			return nil, err
 		}
@@ -572,7 +572,7 @@ func getNetDelegate(client KubeClient, netname string, confdir string) (*types.D
 				var configBytes []byte
 				configBytes, err = getCNIConfigFromFile("", netname)
 				if err == nil {
-					delegate, err := types.LoadDelegateNetConf(configBytes, "", "")
+					delegate, err := types.LoadDelegateNetConf(configBytes, nil, "")
 					if err != nil {
 						return nil, err
 					}

--- a/multus/multus.go
+++ b/multus/multus.go
@@ -181,6 +181,7 @@ func delegateAdd(exec invoke.Exec, ifName string, delegate *types.DelegateNetCon
 		if os.Setenv("MAC", delegate.MacRequest) != nil {
 			return nil, logging.Errorf("cannot set %q mac to %q: %v", delegate.Conf.Type, delegate.MacRequest, err)
 		}
+		logging.Debugf("Set MAC address %q to %q", delegate.MacRequest, ifName)
 	}
 
 	if delegate.ConfListPlugin != false {

--- a/multus/multus.go
+++ b/multus/multus.go
@@ -178,7 +178,7 @@ func delegateAdd(exec invoke.Exec, ifName string, delegate *types.DelegateNetCon
 			return nil, logging.Errorf("failed to parse mac address %q", delegate.MacRequest)
 		}
 
-		if os.Setenv("MAC", delegate.MacRequest) != nil {
+		if os.Setenv("CNI_ARGS", fmt.Sprintf("IgnoreUnknown=true;MAC=%s", delegate.MacRequest)) != nil {
 			return nil, logging.Errorf("cannot set %q mac to %q: %v", delegate.Conf.Type, delegate.MacRequest, err)
 		}
 		logging.Debugf("Set MAC address %q to %q", delegate.MacRequest, ifName)

--- a/multus/multus.go
+++ b/multus/multus.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"os"
 	"path/filepath"
 	"time"
@@ -168,6 +169,18 @@ func delegateAdd(exec invoke.Exec, ifName string, delegate *types.DelegateNetCon
 
 	if err := validateIfName(os.Getenv("CNI_NETNS"), ifName); err != nil {
 		return nil, logging.Errorf("cannot set %q ifname to %q: %v", delegate.Conf.Type, ifName, err)
+	}
+
+	if delegate.MacRequest != "" {
+		// validate Mac address
+		_, err := net.ParseMAC(delegate.MacRequest)
+		if err != nil {
+			return nil, logging.Errorf("failed to parse mac address %q", delegate.MacRequest)
+		}
+
+		if os.Setenv("MAC", delegate.MacRequest) != nil {
+			return nil, logging.Errorf("cannot set %q mac to %q: %v", delegate.Conf.Type, delegate.MacRequest, err)
+		}
 	}
 
 	if delegate.ConfListPlugin != false {

--- a/multus/multus_test.go
+++ b/multus/multus_test.go
@@ -249,7 +249,7 @@ var _ = Describe("multus operations", func() {
 		podNet := `[{"name":"net1",
 	         "interfaceRequest": "test1"},
 		{"name":"net2",
-		 "macRequest": "c2:11:22:33:44:66"}
+		 "mac": "c2:11:22:33:44:66"}
 ]`
 		fakePod := testhelpers.NewFakePod("testpod", podNet)
 		net1 := `{

--- a/multus/multus_test.go
+++ b/multus/multus_test.go
@@ -439,7 +439,7 @@ var _ = Describe("multus operations", func() {
 		]
     }
 }`
-		fExec.addPlugin(nil, "eth0", expectedConf1, nil, nil)
+		fExec.addPlugin(nil, "eth0", "", expectedConf1, nil, nil)
 		os.Setenv("CNI_COMMAND", "ADD")
 		os.Setenv("CNI_IFNAME", "eth0")
 		_, err := cmdAdd(args, fExec, nil)

--- a/types/conf.go
+++ b/types/conf.go
@@ -51,7 +51,10 @@ func LoadDelegateNetConfList(bytes []byte, delegateConf *DelegateNetConf) error 
 }
 
 // Convert raw CNI JSON into a DelegateNetConf structure
-func LoadDelegateNetConf(bytes []byte, ifnameRequest, deviceID string) (*DelegateNetConf, error) {
+func LoadDelegateNetConf(bytes []byte, net *NetworkSelectionElement, deviceID string) (*DelegateNetConf, error) {
+	delegateConf := &DelegateNetConf{}
+	logging.Debugf("LoadDelegateNetConf: %s, %v", string(bytes), net)
+
 	// If deviceID is present, inject this into delegate config
 	if deviceID != "" {
 		if updatedBytes, err := delegateAddDeviceID(bytes, deviceID); err != nil {
@@ -61,8 +64,6 @@ func LoadDelegateNetConf(bytes []byte, ifnameRequest, deviceID string) (*Delegat
 		}
 	}
 
-	delegateConf := &DelegateNetConf{}
-	logging.Debugf("LoadDelegateNetConf: %s, %s", string(bytes), ifnameRequest)
 	if err := json.Unmarshal(bytes, &delegateConf.Conf); err != nil {
 		return nil, logging.Errorf("error in LoadDelegateNetConf - unmarshalling delegate config: %v", err)
 	}
@@ -74,8 +75,13 @@ func LoadDelegateNetConf(bytes []byte, ifnameRequest, deviceID string) (*Delegat
 		}
 	}
 
-	if ifnameRequest != "" {
-		delegateConf.IfnameRequest = ifnameRequest
+	if net != nil {
+		if net.InterfaceRequest != "" {
+			delegateConf.IfnameRequest = net.InterfaceRequest
+		}
+		if net.MacRequest != "" {
+			delegateConf.MacRequest = net.MacRequest
+		}
 	}
 
 	delegateConf.Bytes = bytes

--- a/types/conf.go
+++ b/types/conf.go
@@ -52,18 +52,19 @@ func LoadDelegateNetConfList(bytes []byte, delegateConf *DelegateNetConf) error 
 
 // Convert raw CNI JSON into a DelegateNetConf structure
 func LoadDelegateNetConf(bytes []byte, net *NetworkSelectionElement, deviceID string) (*DelegateNetConf, error) {
-	delegateConf := &DelegateNetConf{}
-	logging.Debugf("LoadDelegateNetConf: %s, %v", string(bytes), net)
+	var err error
+	logging.Debugf("LoadDelegateNetConf: %s, %v, %s", string(bytes), net, deviceID)
 
 	// If deviceID is present, inject this into delegate config
 	if deviceID != "" {
-		if updatedBytes, err := delegateAddDeviceID(bytes, deviceID); err != nil {
+		var updatedBytes []byte
+		if updatedBytes, err = delegateAddDeviceID(bytes, deviceID); err != nil {
 			return nil, logging.Errorf("error in LoadDelegateNetConf - delegateAddDeviceID unable to update delegate config: %v", err)
-		} else {
-			bytes = updatedBytes
 		}
+		bytes = updatedBytes
 	}
 
+	delegateConf := &DelegateNetConf{}
 	if err := json.Unmarshal(bytes, &delegateConf.Conf); err != nil {
 		return nil, logging.Errorf("error in LoadDelegateNetConf - unmarshalling delegate config: %v", err)
 	}

--- a/types/conf.go
+++ b/types/conf.go
@@ -223,7 +223,7 @@ func LoadNetConf(bytes []byte) (*NetConf, error) {
 			if err != nil {
 				return nil, logging.Errorf("error marshalling delegate %d config: %v", idx, err)
 			}
-			delegateConf, err := LoadDelegateNetConf(bytes, "", "")
+			delegateConf, err := LoadDelegateNetConf(bytes, nil, "")
 			if err != nil {
 				return nil, logging.Errorf("failed to load delegate %d config: %v", idx, err)
 			}

--- a/types/types.go
+++ b/types/types.go
@@ -73,6 +73,7 @@ type DelegateNetConf struct {
 	Conf          types.NetConf
 	ConfList      types.NetConfList
 	IfnameRequest string `json:"ifnameRequest,omitempty"`
+	MacRequest    string `json:"macRequest,omitempty"`
 	// MasterPlugin is only used internal housekeeping
 	MasterPlugin bool `json:"-"`
 	// Conflist plugin is only used internal housekeeping

--- a/types/types.go
+++ b/types/types.go
@@ -119,10 +119,10 @@ type NetworkSelectionElement struct {
 	Namespace string `json:"namespace,omitempty"`
 	// IPRequest contains an optional requested IP address for this network
 	// attachment
-	IPRequest string `json:"ipRequest,omitempty"`
+	IPRequest string `json:"ips,omitempty"`
 	// MacRequest contains an optional requested MAC address for this
 	// network attachment
-	MacRequest string `json:"macRequest,omitempty"`
+	MacRequest string `json:"mac,omitempty"`
 	// InterfaceRequest contains an optional requested name for the
 	// network interface this attachment will create in the container
 	InterfaceRequest string `json:"interfaceRequest,omitempty"`


### PR DESCRIPTION
This change supports `mac` to specify MAC address for interface. This feature interworks with the latest 'tuning' CNI plugin of CNCF repo (https://github.com/containernetworking/plugins) and change MAC address.