### PR TITLE
parse kubelet checkpoint file for pod devices

### DIFF
--- a/checkpoint/checkpoint.go
+++ b/checkpoint/checkpoint.go
@@ -1,10 +1,25 @@
+// Copyright (c) 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
 package checkpoint
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 
+	"github.com/intel/multus-cni/logging"
 	"github.com/intel/multus-cni/types"
 )
 
@@ -38,27 +53,41 @@ func getPodEntries() ([]PodDevicesEntry, error) {
 	cpd := &Data{}
 	rawBytes, err := ioutil.ReadFile(checkPointfile)
 	if err != nil {
-		return podEntries, fmt.Errorf("getPodEntries(): error reading file %s\n%v\n", checkPointfile, err)
+		return podEntries, logging.Errorf("getPodEntries(): error reading file %s\n%v\n", checkPointfile, err)
 
 	}
 
 	if err = json.Unmarshal(rawBytes, cpd); err != nil {
-		return podEntries, fmt.Errorf("getPodEntries(): error unmarshalling raw bytes %v", err)
+		return podEntries, logging.Errorf("getPodEntries(): error unmarshalling raw bytes %v", err)
 	}
 
 	return cpd.Data.PodDeviceEntries, nil
 }
 
-// GetComputeDeviceMap returns a map of resourceName to list of device IDs
+var instance map[string]*types.ResourceInfo
+
+// GetComputeDeviceMap returns an instance of a map of ResourceInfo
 func GetComputeDeviceMap(podID string) (map[string]*types.ResourceInfo, error) {
 
+	if instance == nil {
+		if resourceMap, err := getResourceMapFromFile(podID); err == nil {
+			logging.Debugf("GetComputeDeviceMap(): created new instance of resourceMap for Pod: %s", podID)
+			instance = resourceMap
+		} else {
+			logging.Errorf("GetComputeDeviceMap(): error creating resourceMap instance %v", err)
+			return nil, err
+		}
+	}
+	logging.Debugf("GetComputeDeviceMap(): resourceMap instance: %+v", instance)
+	return instance, nil
+}
+
+func getResourceMapFromFile(podID string) (map[string]*types.ResourceInfo, error) {
 	resourceMap := make(map[string]*types.ResourceInfo)
 	podEntires, err := getPodEntries()
-
 	if err != nil {
 		return nil, err
 	}
-
 	for _, pod := range podEntires {
 		if pod.PodUID == podID {
 			entry, ok := resourceMap[pod.ResourceName]
@@ -71,6 +100,5 @@ func GetComputeDeviceMap(podID string) (map[string]*types.ResourceInfo, error) {
 			}
 		}
 	}
-
 	return resourceMap, nil
 }

--- a/checkpoint/checkpoint.go
+++ b/checkpoint/checkpoint.go
@@ -1,0 +1,76 @@
+package checkpoint
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/intel/multus-cni/types"
+)
+
+const (
+	checkPointfile = "/var/lib/kubelet/device-plugins/kubelet_internal_checkpoint"
+)
+
+type PodDevicesEntry struct {
+	PodUID        string
+	ContainerName string
+	ResourceName  string
+	DeviceIDs     []string
+	AllocResp     []byte
+}
+
+type checkpointData struct {
+	PodDeviceEntries  []PodDevicesEntry
+	RegisteredDevices map[string][]string
+}
+
+type Data struct {
+	Data     checkpointData
+	Checksum uint64
+}
+
+// getPodEntries gets all Pod device allocation entries from checkpoint file
+func getPodEntries() ([]PodDevicesEntry, error) {
+
+	podEntries := []PodDevicesEntry{}
+
+	cpd := &Data{}
+	rawBytes, err := ioutil.ReadFile(checkPointfile)
+	if err != nil {
+		return podEntries, fmt.Errorf("getPodEntries(): error reading file %s\n%v\n", checkPointfile, err)
+
+	}
+
+	if err = json.Unmarshal(rawBytes, cpd); err != nil {
+		return podEntries, fmt.Errorf("getPodEntries(): error unmarshalling raw bytes %v", err)
+	}
+
+	return cpd.Data.PodDeviceEntries, nil
+}
+
+// GetComputeDeviceMap returns a map of resourceName to list of device IDs
+func GetComputeDeviceMap(podID string) (map[string]*types.ResourceInfo, error) {
+
+	resourceMap := make(map[string]*types.ResourceInfo)
+	podEntires, err := getPodEntries()
+
+	if err != nil {
+		return nil, err
+	}
+
+	for _, pod := range podEntires {
+		if pod.PodUID == podID {
+			entry, ok := resourceMap[pod.ResourceName]
+			if ok {
+				// already exists; append to it
+				entry.DeviceIDs = append(entry.DeviceIDs, pod.DeviceIDs...)
+			} else {
+				// new entry
+				resourceMap[pod.ResourceName] = &types.ResourceInfo{DeviceIDs: pod.DeviceIDs}
+			}
+		}
+	}
+
+	return resourceMap, nil
+}

--- a/checkpoint/checkpoint_test.go
+++ b/checkpoint/checkpoint_test.go
@@ -1,0 +1,120 @@
+package checkpoint
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"io/ioutil"
+	"testing"
+
+	"github.com/intel/multus-cni/types"
+)
+
+const (
+	fakeTempFile = "/tmp/kubelet_internal_checkpoint"
+)
+
+type fakeCheckpoint struct {
+	fileName string
+}
+
+func (fc *fakeCheckpoint) WriteToFile(inBytes []byte) error {
+	return ioutil.WriteFile(fc.fileName, inBytes, 0600)
+}
+
+func (fc *fakeCheckpoint) DeleteFile() error {
+	return os.Remove(fc.fileName)
+}
+
+func TestCheckpoint(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Checkpoint")
+}
+
+var _ = BeforeSuite(func() {
+	sampleData := `{
+		"Data": {
+			"PodDeviceEntries": [
+			{
+				"PodUID": "970a395d-bb3b-11e8-89df-408d5c537d23",
+				"ContainerName": "appcntr1",
+				"ResourceName": "intel.com/sriov_net_A",
+				"DeviceIDs": [
+				"0000:03:02.3",
+				"0000:03:02.0"
+				],
+				"AllocResp": "CikKC3NyaW92X25ldF9BEhogMDAwMDowMzowMi4zIDAwMDA6MDM6MDIuMA=="
+			}
+			],
+			"RegisteredDevices": {
+			"intel.com/sriov_net_A": [
+				"0000:03:02.1",
+				"0000:03:02.2",
+				"0000:03:02.3",
+				"0000:03:02.0"
+			],
+			"intel.com/sriov_net_B": [
+				"0000:03:06.3",
+				"0000:03:06.0",
+				"0000:03:06.1",
+				"0000:03:06.2"
+			]
+			}
+		},
+		"Checksum": 229855270
+		}`
+
+	fakeCheckpoint := &fakeCheckpoint{fileName: fakeTempFile}
+	err := fakeCheckpoint.WriteToFile([]byte(sampleData))
+	Expect(err).NotTo(HaveOccurred())
+})
+
+var _ = Describe("Kubelet checkpoint data read operations", func() {
+	Context("Using /tmp/kubelet_internal_checkpoint file", func() {
+		var (
+			cp            Checkpoint
+			err           error
+			resourceMap   map[string]*types.ResourceInfo
+			resourceInfo  *types.ResourceInfo
+			resourceAnnot = "intel.com/sriov_net_A"
+		)
+
+		It("should get a Checkpoint instance from file", func() {
+			cp, err = getCheckpoint(fakeTempFile)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should return a ResourceMap instance", func() {
+			rmap, err := cp.GetComputeDeviceMap("970a395d-bb3b-11e8-89df-408d5c537d23")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rmap).NotTo(BeEmpty())
+			resourceMap = rmap
+		})
+
+		It("resourceMap should have value for \"intel.com/sriov_net_A\"", func() {
+			rInfo, ok := resourceMap[resourceAnnot]
+			Expect(ok).To(BeTrue())
+			resourceInfo = rInfo
+		})
+
+		It("should have 2 deviceIDs", func() {
+			Expect(len(resourceInfo.DeviceIDs)).To(BeEquivalentTo(2))
+		})
+
+		It("should have \"0000:03:02.3\" in deviceIDs[0]", func() {
+			Expect(resourceInfo.DeviceIDs[0]).To(BeEquivalentTo("0000:03:02.3"))
+		})
+
+		It("should have \"0000:03:02.0\" in deviceIDs[1]", func() {
+			Expect(resourceInfo.DeviceIDs[1]).To(BeEquivalentTo("0000:03:02.0"))
+		})
+	})
+})
+
+var _ = AfterSuite(func() {
+	fakeCheckpoint := &fakeCheckpoint{fileName: fakeTempFile}
+	err := fakeCheckpoint.DeleteFile()
+	Expect(err).NotTo(HaveOccurred())
+})

--- a/examples/README.md
+++ b/examples/README.md
@@ -60,3 +60,35 @@ A sample `cni-configuration.conf` is provided, typically this file is placed in 
 ## Other considerations
 
 Primarily in this setup one thing that one should consider are the aspects of the `macvlan-conf.yml`, which is likely specific to the configuration of the node on which this resides.
+
+## Passing down device information
+Some CNI plugins require specific device information which maybe pre-allocated by K8s device plugin. This could be indicated by providing `k8s.v1.cni.cncf.io/resourceName` annotaton in its network attachment definition CRD. The file [`examples/sriov-net.yaml`](./sriov-net.yaml) shows an example on how to define a Network attachment definition with specific device allocation information. Multus will get allocated device information and make them available for CNI plugin to work on.
+
+In this exmaple (shown below), it is expected that an [SRIOV Device Plugin](https://github.com/intel/sriov-network-device-plugin/tree/dev/k8s-deviceid-model) making a pool of SRIOV VFs available to the K8s with `intel.com/sriov` as their resourceName. Any device allocated from this resource pool will be passed down by Multus to the [sriov-cni](https://github.com/intel/sriov-cni/tree/dev/k8s-deviceid-model) plugin in `deviceID` field. This is up to the sriov-cni plugin to capture this information and work with this specific device information.
+
+```yaml
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: sriov-net-a
+  annotations:
+    k8s.v1.cni.cncf.io/resourceName: intel.com/sriov
+spec:
+  config: '{
+  "type": "sriov",
+  "vlan": 1000,
+  "ipam": {
+    "type": "host-local",
+    "subnet": "10.56.217.0/24",
+    "rangeStart": "10.56.217.171",
+    "rangeEnd": "10.56.217.181",
+    "routes": [{
+      "dst": "0.0.0.0/0"
+    }],
+    "gateway": "10.56.217.1"
+  }
+}'
+```
+The [net-resource-sample-pod.yaml](./net-resource-sample-pod.yaml) is an exmaple Pod manifest file that requesting a SRIOV device from a host which is then configured using the above network attachement definition.
+
+>For further information on how to configure SRIOV Device Plugin and SRIOV-CNI please refer to the links given above.

--- a/examples/README.md
+++ b/examples/README.md
@@ -64,7 +64,7 @@ Primarily in this setup one thing that one should consider are the aspects of th
 ## Passing down device information
 Some CNI plugins require specific device information which maybe pre-allocated by K8s device plugin. This could be indicated by providing `k8s.v1.cni.cncf.io/resourceName` annotaton in its network attachment definition CRD. The file [`examples/sriov-net.yaml`](./sriov-net.yaml) shows an example on how to define a Network attachment definition with specific device allocation information. Multus will get allocated device information and make them available for CNI plugin to work on.
 
-In this exmaple (shown below), it is expected that an [SRIOV Device Plugin](https://github.com/intel/sriov-network-device-plugin/tree/dev/k8s-deviceid-model) making a pool of SRIOV VFs available to the K8s with `intel.com/sriov` as their resourceName. Any device allocated from this resource pool will be passed down by Multus to the [sriov-cni](https://github.com/intel/sriov-cni/tree/dev/k8s-deviceid-model) plugin in `deviceID` field. This is up to the sriov-cni plugin to capture this information and work with this specific device information.
+In this exmaple (shown below), it is expected that an [SRIOV Device Plugin](https://github.com/intel/sriov-network-device-plugin/) making a pool of SRIOV VFs available to the K8s with `intel.com/sriov` as their resourceName. Any device allocated from this resource pool will be passed down by Multus to the [sriov-cni](https://github.com/intel/sriov-cni/tree/dev/k8s-deviceid-model) plugin in `deviceID` field. This is up to the sriov-cni plugin to capture this information and work with this specific device information.
 
 ```yaml
 apiVersion: "k8s.cni.cncf.io/v1"

--- a/examples/net-resource-sample-pod.yaml
+++ b/examples/net-resource-sample-pod.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: testpod1
+  labels:
+    env: test
+  annotations:
+    k8s.v1.cni.cncf.io/networks: sriov-net-a
+spec:
+  containers:
+  - name: appcntr1
+    image: centos/tools
+    imagePullPolicy: IfNotPresent
+    command: [ "/bin/bash", "-c", "--" ]
+    args: [ "while true; do sleep 300000; done;" ]
+    resources:
+      requests:
+        intel.com/sriov: '1'
+      limits:
+        intel.com/sriov: '1'
+  restartPolicy: "Never"

--- a/examples/sriov-net.yaml
+++ b/examples/sriov-net.yaml
@@ -1,0 +1,21 @@
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: sriov-net-a
+  annotations:
+    k8s.v1.cni.cncf.io/resourceName: intel.com/sriov
+spec:
+  config: '{
+  "type": "sriov",
+  "vlan": 1000,
+  "ipam": {
+    "type": "host-local",
+    "subnet": "10.56.217.0/24",
+    "rangeStart": "10.56.217.171",
+    "rangeEnd": "10.56.217.181",
+    "routes": [{
+      "dst": "0.0.0.0/0"
+    }],
+    "gateway": "10.56.217.1"
+  }
+}'

--- a/k8sclient/k8sclient.go
+++ b/k8sclient/k8sclient.go
@@ -345,7 +345,7 @@ func getKubernetesDelegate(client KubeClient, net *types.NetworkSelectionElement
 		return nil, resourceMap, logging.Errorf("getKubernetesDelegate: failed to get the netplugin data: %v", err)
 	}
 
-	// Get resourceName annotation from NetDefinition
+	// Get resourceName annotation from NetworkAttachmentDefinition
 	deviceID := ""
 	resourceName, ok := customResource.Metadata.Annotations[resourceNameAnnot]
 	if ok && podID != "" {

--- a/types/types.go
+++ b/types/types.go
@@ -119,3 +119,9 @@ type K8sArgs struct {
 	K8S_POD_NAMESPACE          types.UnmarshallableString
 	K8S_POD_INFRA_CONTAINER_ID types.UnmarshallableString
 }
+
+// ResourceInfo is struct to hold Pod device allocation information
+type ResourceInfo struct {
+	Index     int
+	DeviceIDs []string
+}


### PR DESCRIPTION
Enabling kubelete checkpoint file  parsing to get Pod device info
so that these device information can be passed into CNI plugins that
need specific device information to work on.

Change-Id: I6630f56adc0a8307f575fc09ce9090c1ffca0337