### PR TITLE
Updates to release-v3 stable branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,12 +13,7 @@ before_install:
   - go get github.com/mattn/goveralls
 
 install:
-  # workaround golint install error in https://github.com/golang/lint/issues/288
-  - mkdir -p $GOPATH/src/golang.org/x
-  - pushd $GOPATH/src/golang.org/x
-  - git clone https://github.com/golang/lint.git
-  - go get github.com/golang/lint/golint
-  - popd
+  - go get -u golang.org/x/lint/golint
 
 before_script:
   - golint ./multus/... | grep -v ALL_CAPS | xargs -r false

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ language: go
 dist: trusty
 env:
   global:
-    - REGISTRY_USER=nfvperobot
-    - secure: "LnQV09sy5nfrJd0PKAbxYPdKJ5QtLECofsunYfVk7tFp+ivKyZBXHwi4V4aGFuB2SqCnpauXBRTLet8hrfm5kN9ZZQRqy0WNs/fJHdFC6YKOKwyCQwczFb1by/iTX68dxWc2nK9+Opi6s/81Bh5yb3Oquqzdk+OEgaQHz2KP7BwI4yDrobinBR5laJ4KdxZJYgYx4mP6uUPxj7UZww+HaWqyiGy8cAeK3L81sGjxXJIYTRRfG1J4pifI5A3c3IOJRID0pvifgUIsQXp5MHpx+nxmhRJ7KMBLeNkUKruLTEsufgGCvhY5eWpdBhVN2YefGTqlKBCtKEqRUPlLbP5eJGUdY1PlUMUnQsr+FRWAZz90A1TESOZXZqDs4xR1ox1wX7mBUeelViXvUfLQB9sOD8G86FkXqNTqx/thp3x0Dqgy44pL+12Y3k5xVZmIsWDSpGmmIe1jOCsoL26Fdic+dTO/l3mx3KP1+gPNqbScuJsccLyPsr96uFCBCPJ2mSy7nCqb01KZTbbkIvv6oOCQ+Mfq8MT9lkxf6FJ+K+7vVbcgshOGhqA/l1UO3rKxnGt8Rkj/5XoHkcjXjM6YzT5LvljVWszJGXeTQxGjcsPrK2AscyX7JvNp/AMElII/Hxm6P0NESfV0whrZHyVOaqIRrbhUsK9j4YP8IMFoI4qYp4g="
+    - REGISTRY_USER=${REGISTRY_USER}
+    - secure: "${REGISTRY_SECURE}"
 
 before_install:
   - sudo apt-get update -qq
@@ -42,7 +42,7 @@ before_deploy:
 deploy:
   - provider: releases
     api_key:
-      secure: "iy7eqzXNvb/juc+5eVPQ/pFYDTCqDt8Zjt63n+zEK856Qzr2aEZwwOguMWs78XFDMFXagCs5PRTvtvZz8apoTfHX7Wkss3kRyEziAkuldQbH5yGDvpGyHsGBw78N95hauMoogefE7NuuLG3qRSWPeVz8RAKGhP7ADwEVyyfQKKYdum3Bqrz0D89HqKbCQqs3eZae7ppDIler3lab9WAQGuKNJ2HL6mqREVe48kb8sdsuSr+yV4qwVrBDNhXxQDxAT6LYuMXbknE7qTde2vViP13ZHpptbuZqiZG2ytzReIIs/iC9AWoIQXr3XTXl9z8fqlC3VljPCikBWVcmxDFA2aANYzx3M/7fMOO/DniwNhlZc9+pYfAkUrpoQPfPOWNqf45Qz0jP3wk49xy5hxEqe/rfmo5lipSsqeUsk+j3pT8kjVIAnDLrQpxSx7xwnijPLgtm34UwROVowfwLlOhE/7mUOFCbYlzEo3CKvjDN3Kmn35yHEueuu//Gv5jesVYvgcNPBHqaTKb5AXVTqymNBtA43PchLJ8gCC1mNukzSZifQP996vzbV5c9AxzBLjWbiDJ3lOFIpNhF8Sed0m0C0RylrTXHTX5TSrlMdXXffzYwbjJ96J+cFPBTpJNfSn+3N7hiart1r1k1bSXoPqYW4+94M8E1eZ5LjszoeiZbRrI="
+      secure: "${DEPLOY_SECURE}"
     file_glob: true
     file: "$TRAVIS_BUILD_DIR/dist/*/*.gz"
     skip_cleanup: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,4 @@ ADD ./images/entrypoint.sh /
 # does it require a root user?
 # USER 1001
 
-ENTRYPOINT [/entrypoint.sh]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,4 @@ ADD ./images/entrypoint.sh /
 # does it require a root user?
 # USER 1001
 
-ENTRYPOINT /entrypoint.sh
+ENTRYPOINT [/entrypoint.sh]

--- a/README.md
+++ b/README.md
@@ -497,7 +497,7 @@ You may configure the logging level by using the `LogLevel` option in your CNI c
 Allocation of the Network device(such as SRIOV VFs) are done by Device plugins(Eg.SRIOV Network device plugin), Multus developed to work in the co-existence enviroment to work with device plugin by passing down the allocated device information to the CNI plugins.
 
 * [Device plugin & CNI, NUMA Manager alignment - technical architecture document](https://docs.google.com/document/d/1Ewe9Of84GkP0b2Q2PC0y9RVZNkN2WeVEagX9m99Nrzc/edit)
-* Reference implementation : [SRIOV Network devie plugin](https://github.com/intel/sriov-network-device-plugin)
+* Reference implementation : [SRIOV Network device plugin](https://github.com/intel/sriov-network-device-plugin)
 * Example: [How to make Multus work with device plugin?](https://github.com/intel/multus-cni/tree/master/examples#passing-down-device-information)
 ## Testing Multus CNI
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
          * [Verifying Pod network interfaces](#verifying-pod-network-interfaces)
       * [Using with Multus conf file](#using-with-multus-conf-file)
       * [Logging Options](#logging-options)
+      * [How to use with Network Device plugins?](#cni-running-with-network-device-plugin)
       * [Testing Multus CNI](#testing-multus-cni)
          * [Multiple flannel networks](#multiple-flannel-networks)
             * [Configure Kubernetes with CNI](#configure-kubernetes-with-cni)
@@ -491,7 +492,13 @@ You may configure the logging level by using the `LogLevel` option in your CNI c
 ```
     "LogLevel": "debug",
 ```
+## CNI running with Network device plugin
 
+Allocation of the Network device(such as SRIOV VFs) are done by Device plugins(Eg.SRIOV Network device plugin), Multus developed to work in the co-existence enviroment to work with device plugin by passing down the allocated device information to the CNI plugins.
+
+* [Device plugin & CNI, NUMA Manager alignment - technical architecture document](https://docs.google.com/document/d/1Ewe9Of84GkP0b2Q2PC0y9RVZNkN2WeVEagX9m99Nrzc/edit)
+* Reference implementation : [SRIOV Network devie plugin](https://github.com/intel/sriov-network-device-plugin)
+* Example: [How to make Multus work with device plugin?](https://github.com/intel/multus-cni/tree/master/examples#passing-down-device-information)
 ## Testing Multus CNI
 
 ### Multiple flannel networks

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
       * [Using with Multus conf file](#using-with-multus-conf-file)
       * [Logging Options](#logging-options)
       * [How to use with Network Device plugins?](#cni-running-with-network-device-plugin)
+      * [Default Network Readiness Checks](#default-network-readiness-checks)
       * [Testing Multus CNI](#testing-multus-cni)
          * [Multiple flannel networks](#multiple-flannel-networks)
             * [Configure Kubernetes with CNI](#configure-kubernetes-with-cni)
@@ -499,6 +500,21 @@ Allocation of the Network device(such as SRIOV VFs) are done by Device plugins(E
 * [Device plugin & CNI, NUMA Manager alignment - technical architecture document](https://docs.google.com/document/d/1Ewe9Of84GkP0b2Q2PC0y9RVZNkN2WeVEagX9m99Nrzc/edit)
 * Reference implementation : [SRIOV Network device plugin](https://github.com/intel/sriov-network-device-plugin)
 * Example: [How to make Multus work with device plugin?](https://github.com/intel/multus-cni/tree/master/examples#passing-down-device-information)
+
+## Default Network Readiness Checks
+
+You may wish for your "default network" (that is, the CNI plugin & its configuration you specify as your default delegate) to become ready before you attach networks with Multus. This is disabled by default and not used unless you add the readiness check option(s) to your CNI configuration file.
+
+For example, if you use Flannel as a default network, the recommended method for Flannel to be installed is via a daemonset that also drops a configuration file in `/etc/cni/net.d/`. This may apply to other plugins that place that configuration file upon their readiness, hence, Multus uses their configuration filename as a semaphore and optionally waits to attach networks to pods until that file exists.
+
+In this manner, you may prevent pods from crash looping, and instead wait for that default network to be ready.
+
+Only one option is necessary to configure this functionality:
+
+* `readinessindicatorfile`: The path to a file whose existance denotes that the default network is ready.
+
+*NOTE*: If `readinessindicatorfile` is unset, or is an empty string, this functionality will be disabled, and is disabled by default.
+
 ## Testing Multus CNI
 
 ### Multiple flannel networks

--- a/checkpoint/checkpoint.go
+++ b/checkpoint/checkpoint.go
@@ -1,10 +1,25 @@
+// Copyright (c) 2018 Intel Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
 package checkpoint
 
 import (
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 
+	"github.com/intel/multus-cni/logging"
 	"github.com/intel/multus-cni/types"
 )
 
@@ -38,27 +53,41 @@ func getPodEntries() ([]PodDevicesEntry, error) {
 	cpd := &Data{}
 	rawBytes, err := ioutil.ReadFile(checkPointfile)
 	if err != nil {
-		return podEntries, fmt.Errorf("getPodEntries(): error reading file %s\n%v\n", checkPointfile, err)
+		return podEntries, logging.Errorf("getPodEntries(): error reading file %s\n%v\n", checkPointfile, err)
 
 	}
 
 	if err = json.Unmarshal(rawBytes, cpd); err != nil {
-		return podEntries, fmt.Errorf("getPodEntries(): error unmarshalling raw bytes %v", err)
+		return podEntries, logging.Errorf("getPodEntries(): error unmarshalling raw bytes %v", err)
 	}
 
 	return cpd.Data.PodDeviceEntries, nil
 }
 
-// GetComputeDeviceMap returns a map of resourceName to list of device IDs
+var instance map[string]*types.ResourceInfo
+
+// GetComputeDeviceMap returns an instance of a map of ResourceInfo
 func GetComputeDeviceMap(podID string) (map[string]*types.ResourceInfo, error) {
 
+	if instance == nil {
+		if resourceMap, err := getResourceMapFromFile(podID); err == nil {
+			logging.Debugf("GetComputeDeviceMap(): created new instance of resourceMap for Pod: %s", podID)
+			instance = resourceMap
+		} else {
+			logging.Errorf("GetComputeDeviceMap(): error creating resourceMap instance %v", err)
+			return nil, err
+		}
+	}
+	logging.Debugf("GetComputeDeviceMap(): resourceMap instance: %+v", instance)
+	return instance, nil
+}
+
+func getResourceMapFromFile(podID string) (map[string]*types.ResourceInfo, error) {
 	resourceMap := make(map[string]*types.ResourceInfo)
 	podEntires, err := getPodEntries()
-
 	if err != nil {
 		return nil, err
 	}
-
 	for _, pod := range podEntires {
 		if pod.PodUID == podID {
 			entry, ok := resourceMap[pod.ResourceName]
@@ -71,6 +100,5 @@ func GetComputeDeviceMap(podID string) (map[string]*types.ResourceInfo, error) {
 			}
 		}
 	}
-
 	return resourceMap, nil
 }

--- a/checkpoint/checkpoint.go
+++ b/checkpoint/checkpoint.go
@@ -1,0 +1,76 @@
+package checkpoint
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/intel/multus-cni/types"
+)
+
+const (
+	checkPointfile = "/var/lib/kubelet/device-plugins/kubelet_internal_checkpoint"
+)
+
+type PodDevicesEntry struct {
+	PodUID        string
+	ContainerName string
+	ResourceName  string
+	DeviceIDs     []string
+	AllocResp     []byte
+}
+
+type checkpointData struct {
+	PodDeviceEntries  []PodDevicesEntry
+	RegisteredDevices map[string][]string
+}
+
+type Data struct {
+	Data     checkpointData
+	Checksum uint64
+}
+
+// getPodEntries gets all Pod device allocation entries from checkpoint file
+func getPodEntries() ([]PodDevicesEntry, error) {
+
+	podEntries := []PodDevicesEntry{}
+
+	cpd := &Data{}
+	rawBytes, err := ioutil.ReadFile(checkPointfile)
+	if err != nil {
+		return podEntries, fmt.Errorf("getPodEntries(): error reading file %s\n%v\n", checkPointfile, err)
+
+	}
+
+	if err = json.Unmarshal(rawBytes, cpd); err != nil {
+		return podEntries, fmt.Errorf("getPodEntries(): error unmarshalling raw bytes %v", err)
+	}
+
+	return cpd.Data.PodDeviceEntries, nil
+}
+
+// GetComputeDeviceMap returns a map of resourceName to list of device IDs
+func GetComputeDeviceMap(podID string) (map[string]*types.ResourceInfo, error) {
+
+	resourceMap := make(map[string]*types.ResourceInfo)
+	podEntires, err := getPodEntries()
+
+	if err != nil {
+		return nil, err
+	}
+
+	for _, pod := range podEntires {
+		if pod.PodUID == podID {
+			entry, ok := resourceMap[pod.ResourceName]
+			if ok {
+				// already exists; append to it
+				entry.DeviceIDs = append(entry.DeviceIDs, pod.DeviceIDs...)
+			} else {
+				// new entry
+				resourceMap[pod.ResourceName] = &types.ResourceInfo{DeviceIDs: pod.DeviceIDs}
+			}
+		}
+	}
+
+	return resourceMap, nil
+}

--- a/checkpoint/checkpoint_test.go
+++ b/checkpoint/checkpoint_test.go
@@ -1,0 +1,120 @@
+package checkpoint
+
+import (
+	"os"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"io/ioutil"
+	"testing"
+
+	"github.com/intel/multus-cni/types"
+)
+
+const (
+	fakeTempFile = "/tmp/kubelet_internal_checkpoint"
+)
+
+type fakeCheckpoint struct {
+	fileName string
+}
+
+func (fc *fakeCheckpoint) WriteToFile(inBytes []byte) error {
+	return ioutil.WriteFile(fc.fileName, inBytes, 0600)
+}
+
+func (fc *fakeCheckpoint) DeleteFile() error {
+	return os.Remove(fc.fileName)
+}
+
+func TestCheckpoint(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Checkpoint")
+}
+
+var _ = BeforeSuite(func() {
+	sampleData := `{
+		"Data": {
+			"PodDeviceEntries": [
+			{
+				"PodUID": "970a395d-bb3b-11e8-89df-408d5c537d23",
+				"ContainerName": "appcntr1",
+				"ResourceName": "intel.com/sriov_net_A",
+				"DeviceIDs": [
+				"0000:03:02.3",
+				"0000:03:02.0"
+				],
+				"AllocResp": "CikKC3NyaW92X25ldF9BEhogMDAwMDowMzowMi4zIDAwMDA6MDM6MDIuMA=="
+			}
+			],
+			"RegisteredDevices": {
+			"intel.com/sriov_net_A": [
+				"0000:03:02.1",
+				"0000:03:02.2",
+				"0000:03:02.3",
+				"0000:03:02.0"
+			],
+			"intel.com/sriov_net_B": [
+				"0000:03:06.3",
+				"0000:03:06.0",
+				"0000:03:06.1",
+				"0000:03:06.2"
+			]
+			}
+		},
+		"Checksum": 229855270
+		}`
+
+	fakeCheckpoint := &fakeCheckpoint{fileName: fakeTempFile}
+	err := fakeCheckpoint.WriteToFile([]byte(sampleData))
+	Expect(err).NotTo(HaveOccurred())
+})
+
+var _ = Describe("Kubelet checkpoint data read operations", func() {
+	Context("Using /tmp/kubelet_internal_checkpoint file", func() {
+		var (
+			cp            Checkpoint
+			err           error
+			resourceMap   map[string]*types.ResourceInfo
+			resourceInfo  *types.ResourceInfo
+			resourceAnnot = "intel.com/sriov_net_A"
+		)
+
+		It("should get a Checkpoint instance from file", func() {
+			cp, err = getCheckpoint(fakeTempFile)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should return a ResourceMap instance", func() {
+			rmap, err := cp.GetComputeDeviceMap("970a395d-bb3b-11e8-89df-408d5c537d23")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rmap).NotTo(BeEmpty())
+			resourceMap = rmap
+		})
+
+		It("resourceMap should have value for \"intel.com/sriov_net_A\"", func() {
+			rInfo, ok := resourceMap[resourceAnnot]
+			Expect(ok).To(BeTrue())
+			resourceInfo = rInfo
+		})
+
+		It("should have 2 deviceIDs", func() {
+			Expect(len(resourceInfo.DeviceIDs)).To(BeEquivalentTo(2))
+		})
+
+		It("should have \"0000:03:02.3\" in deviceIDs[0]", func() {
+			Expect(resourceInfo.DeviceIDs[0]).To(BeEquivalentTo("0000:03:02.3"))
+		})
+
+		It("should have \"0000:03:02.0\" in deviceIDs[1]", func() {
+			Expect(resourceInfo.DeviceIDs[1]).To(BeEquivalentTo("0000:03:02.0"))
+		})
+	})
+})
+
+var _ = AfterSuite(func() {
+	fakeCheckpoint := &fakeCheckpoint{fileName: fakeTempFile}
+	err := fakeCheckpoint.DeleteFile()
+	Expect(err).NotTo(HaveOccurred())
+})

--- a/examples/README.md
+++ b/examples/README.md
@@ -60,3 +60,35 @@ A sample `cni-configuration.conf` is provided, typically this file is placed in 
 ## Other considerations
 
 Primarily in this setup one thing that one should consider are the aspects of the `macvlan-conf.yml`, which is likely specific to the configuration of the node on which this resides.
+
+## Passing down device information
+Some CNI plugins require specific device information which maybe pre-allocated by K8s device plugin. This could be indicated by providing `k8s.v1.cni.cncf.io/resourceName` annotaton in its network attachment definition CRD. The file [`examples/sriov-net.yaml`](./sriov-net.yaml) shows an example on how to define a Network attachment definition with specific device allocation information. Multus will get allocated device information and make them available for CNI plugin to work on.
+
+In this exmaple (shown below), it is expected that an [SRIOV Device Plugin](https://github.com/intel/sriov-network-device-plugin/tree/dev/k8s-deviceid-model) making a pool of SRIOV VFs available to the K8s with `intel.com/sriov` as their resourceName. Any device allocated from this resource pool will be passed down by Multus to the [sriov-cni](https://github.com/intel/sriov-cni/tree/dev/k8s-deviceid-model) plugin in `deviceID` field. This is up to the sriov-cni plugin to capture this information and work with this specific device information.
+
+```yaml
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: sriov-net-a
+  annotations:
+    k8s.v1.cni.cncf.io/resourceName: intel.com/sriov
+spec:
+  config: '{
+  "type": "sriov",
+  "vlan": 1000,
+  "ipam": {
+    "type": "host-local",
+    "subnet": "10.56.217.0/24",
+    "rangeStart": "10.56.217.171",
+    "rangeEnd": "10.56.217.181",
+    "routes": [{
+      "dst": "0.0.0.0/0"
+    }],
+    "gateway": "10.56.217.1"
+  }
+}'
+```
+The [net-resource-sample-pod.yaml](./net-resource-sample-pod.yaml) is an exmaple Pod manifest file that requesting a SRIOV device from a host which is then configured using the above network attachement definition.
+
+>For further information on how to configure SRIOV Device Plugin and SRIOV-CNI please refer to the links given above.

--- a/examples/README.md
+++ b/examples/README.md
@@ -64,7 +64,7 @@ Primarily in this setup one thing that one should consider are the aspects of th
 ## Passing down device information
 Some CNI plugins require specific device information which maybe pre-allocated by K8s device plugin. This could be indicated by providing `k8s.v1.cni.cncf.io/resourceName` annotaton in its network attachment definition CRD. The file [`examples/sriov-net.yaml`](./sriov-net.yaml) shows an example on how to define a Network attachment definition with specific device allocation information. Multus will get allocated device information and make them available for CNI plugin to work on.
 
-In this exmaple (shown below), it is expected that an [SRIOV Device Plugin](https://github.com/intel/sriov-network-device-plugin/tree/dev/k8s-deviceid-model) making a pool of SRIOV VFs available to the K8s with `intel.com/sriov` as their resourceName. Any device allocated from this resource pool will be passed down by Multus to the [sriov-cni](https://github.com/intel/sriov-cni/tree/dev/k8s-deviceid-model) plugin in `deviceID` field. This is up to the sriov-cni plugin to capture this information and work with this specific device information.
+In this exmaple (shown below), it is expected that an [SRIOV Device Plugin](https://github.com/intel/sriov-network-device-plugin/) making a pool of SRIOV VFs available to the K8s with `intel.com/sriov` as their resourceName. Any device allocated from this resource pool will be passed down by Multus to the [sriov-cni](https://github.com/intel/sriov-cni/tree/dev/k8s-deviceid-model) plugin in `deviceID` field. This is up to the sriov-cni plugin to capture this information and work with this specific device information.
 
 ```yaml
 apiVersion: "k8s.cni.cncf.io/v1"

--- a/examples/net-resource-sample-pod.yaml
+++ b/examples/net-resource-sample-pod.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: testpod1
+  labels:
+    env: test
+  annotations:
+    k8s.v1.cni.cncf.io/networks: sriov-net-a
+spec:
+  containers:
+  - name: appcntr1
+    image: centos/tools
+    imagePullPolicy: IfNotPresent
+    command: [ "/bin/bash", "-c", "--" ]
+    args: [ "while true; do sleep 300000; done;" ]
+    resources:
+      requests:
+        intel.com/sriov: '1'
+      limits:
+        intel.com/sriov: '1'
+  restartPolicy: "Never"

--- a/examples/sriov-net.yaml
+++ b/examples/sriov-net.yaml
@@ -1,0 +1,21 @@
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: sriov-net-a
+  annotations:
+    k8s.v1.cni.cncf.io/resourceName: intel.com/sriov
+spec:
+  config: '{
+  "type": "sriov",
+  "vlan": 1000,
+  "ipam": {
+    "type": "host-local",
+    "subnet": "10.56.217.0/24",
+    "rangeStart": "10.56.217.171",
+    "rangeEnd": "10.56.217.181",
+    "routes": [{
+      "dst": "0.0.0.0/0"
+    }],
+    "gateway": "10.56.217.1"
+  }
+}'

--- a/images/README.md
+++ b/images/README.md
@@ -31,10 +31,12 @@ You can get get help with the `--help` flag.
 ```
 $ ./entrypoint.sh --help
 
-This is an entrypoint script for Multus CNI to overlay its
-binary and configuration into locations in a filesystem.
-The configuration & binary file will be copied to the 
-corresponding configuration directory.
+This is an entrypoint script for Multus CNI to overlay its binary and
+configuration into locations in a filesystem. The configuration & binary file
+will be copied to the corresponding configuration directory. When
+`--multus-conf-file=auto` is used, 00-multus.conf will be automatically
+generated from the CNI configuration file of the master plugin (the first file
+in lexicographical order in cni-conf-dir).
 
 ./entrypoint.sh
     -h --help
@@ -42,6 +44,7 @@ corresponding configuration directory.
     --cni-bin-dir=/host/opt/cni/bin
     --multus-conf-file=/usr/src/multus-cni/images/70-multus.conf
     --multus-bin-file=/usr/src/multus-cni/bin/multus
+    --multus-kubeconfig-file-host=/etc/cni/net.d/multus.d/multus.kubeconfig
 ```
 
 You must use an `=` to delimit the parameter name and the value. For example you may set a custom `cni-conf-dir` like so:
@@ -59,7 +62,7 @@ Note: You'll noticed that there's a `/host/...` directory from the root for the 
 Example docker run command:
 
 ```
-$ docker run -it -v /opt/cni/bin/:/host/opt/cni/bin/ -v /etc/cni/net.d/:/host/etc/cni/net.d/ --entrypoint=/bin/bash dougbtv/multus 
+$ docker run -it -v /opt/cni/bin/:/host/opt/cni/bin/ -v /etc/cni/net.d/:/host/etc/cni/net.d/ --entrypoint=/bin/bash dougbtv/multus
 ```
 
 Originally inspired by and is a portmanteau of the [Flannel daemonset](https://github.com/coreos/flannel/blob/master/Documentation/kube-flannel.yml), the [Calico Daemonset](https://github.com/projectcalico/calico/blob/master/v2.0/getting-started/kubernetes/installation/hosted/k8s-backend-addon-manager/calico-daemonset.yaml), and the [Calico CNI install bash script](https://github.com/projectcalico/cni-plugin/blob/be4df4db2e47aa7378b1bdf6933724bac1f348d0/k8s-install/scripts/install-cni.sh#L104-L153).

--- a/images/entrypoint.sh
+++ b/images/entrypoint.sh
@@ -151,7 +151,7 @@ fi
 
 if [ "$MULTUS_CONF_FILE" == "auto" ]; then
   echo "Generating Multus configuration file ..."
-  MASTER_PLUGIN="$(ls $CNI_CONF_DIR | grep .conf | head -1)"
+  MASTER_PLUGIN="$(ls $CNI_CONF_DIR | grep -E '\.conf(list)?$' | head -1)"
   if [ "$MASTER_PLUGIN" == "" ]; then
     echo "Error: Multus could not be configured: no master plugin was found."
     exit 1;

--- a/k8sclient/k8sclient.go
+++ b/k8sclient/k8sclient.go
@@ -345,7 +345,7 @@ func getKubernetesDelegate(client KubeClient, net *types.NetworkSelectionElement
 		return nil, resourceMap, logging.Errorf("getKubernetesDelegate: failed to get the netplugin data: %v", err)
 	}
 
-	// Get resourceName annotation from NetDefinition
+	// Get resourceName annotation from NetworkAttachmentDefinition
 	deviceID := ""
 	resourceName, ok := customResource.Metadata.Annotations[resourceNameAnnot]
 	if ok && podID != "" {

--- a/types/conf.go
+++ b/types/conf.go
@@ -27,9 +27,9 @@ import (
 )
 
 const (
-	defaultCNIDir             = "/var/lib/cni/multus"
-	defaultConfDir            = "/etc/cni/multus/net.d"
-	defaultBinDir             = "/opt/cni/bin"
+	defaultCNIDir                 = "/var/lib/cni/multus"
+	defaultConfDir                = "/etc/cni/multus/net.d"
+	defaultBinDir                 = "/opt/cni/bin"
 	defaultReadinessIndicatorFile = ""
 )
 
@@ -104,7 +104,7 @@ func LoadCNIRuntimeConf(args *skel.CmdArgs, k8sArgs *K8sArgs, ifName string) (*l
 }
 
 func LoadNetworkStatus(r types.Result, netName string, defaultNet bool) (*NetworkStatus, error) {
-	logging.Debugf("LoadNetworkStatus: %v, %s, %s", r, netName, defaultNet)
+	logging.Debugf("LoadNetworkStatus: %v, %s, %v", r, netName, defaultNet)
 
 	// Convert whatever the IPAM result was into the current Result type
 	result, err := current.NewResultFromResult(r)

--- a/types/conf.go
+++ b/types/conf.go
@@ -27,9 +27,10 @@ import (
 )
 
 const (
-	defaultCNIDir  = "/var/lib/cni/multus"
-	defaultConfDir = "/etc/cni/multus/net.d"
-	defaultBinDir  = "/opt/cni/bin"
+	defaultCNIDir             = "/var/lib/cni/multus"
+	defaultConfDir            = "/etc/cni/multus/net.d"
+	defaultBinDir             = "/opt/cni/bin"
+	defaultReadinessIndicatorFile = ""
 )
 
 func LoadDelegateNetConfList(bytes []byte, delegateConf *DelegateNetConf) error {
@@ -192,6 +193,10 @@ func LoadNetConf(bytes []byte) (*NetConf, error) {
 
 	if netconf.BinDir == "" {
 		netconf.BinDir = defaultBinDir
+	}
+
+	if netconf.ReadinessIndicatorFile == "" {
+		netconf.ReadinessIndicatorFile = defaultReadinessIndicatorFile
 	}
 
 	for idx, rawConf := range netconf.RawDelegates {

--- a/types/conf_test.go
+++ b/types/conf_test.go
@@ -81,4 +81,40 @@ var _ = Describe("config operations", func() {
 		_, err := LoadNetConf([]byte(conf))
 		Expect(err).To(HaveOccurred())
 	})
+
+	It("has defaults set for network readiness", func() {
+		conf := `{
+    "name": "defaultnetwork",
+    "type": "multus",
+    "kubeconfig": "/etc/kubernetes/kubelet.conf",
+    "delegates": [{
+      "cniVersion": "0.3.0",
+      "name": "defaultnetwork",
+      "type": "flannel",
+      "isDefaultGateway": true
+    }]
+}`
+		netConf, err := LoadNetConf([]byte(conf))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(netConf.ReadinessIndicatorFile).To(Equal(""))
+	})
+
+	It("honors overrides for network readiness", func() {
+		conf := `{
+    "name": "defaultnetwork",
+    "type": "multus",
+    "readinessindicatorfile": "/etc/cni/net.d/foo",
+    "kubeconfig": "/etc/kubernetes/kubelet.conf",
+    "delegates": [{
+      "cniVersion": "0.3.0",
+      "name": "defaultnetwork",
+      "type": "flannel",
+      "isDefaultGateway": true
+    }]
+}`
+		netConf, err := LoadNetConf([]byte(conf))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(netConf.ReadinessIndicatorFile).To(Equal("/etc/cni/net.d/foo"))
+	})
+
 })

--- a/types/types.go
+++ b/types/types.go
@@ -119,3 +119,9 @@ type K8sArgs struct {
 	K8S_POD_NAMESPACE          types.UnmarshallableString
 	K8S_POD_INFRA_CONTAINER_ID types.UnmarshallableString
 }
+
+// ResourceInfo is struct to hold Pod device allocation information
+type ResourceInfo struct {
+	Index     int
+	DeviceIDs []string
+}

--- a/types/types.go
+++ b/types/types.go
@@ -36,12 +36,13 @@ type NetConf struct {
 	CNIDir  string `json:"cniDir"`
 	BinDir  string `json:"binDir"`
 	// RawDelegates is private to the NetConf class; use Delegates instead
-	RawDelegates []map[string]interface{} `json:"delegates"`
-	Delegates    []*DelegateNetConf       `json:"-"`
-	NetStatus    []*NetworkStatus         `json:"-"`
-	Kubeconfig   string                   `json:"kubeconfig"`
-	LogFile      string                   `json:"logFile"`
-	LogLevel     string                   `json:"logLevel"`
+	RawDelegates           []map[string]interface{} `json:"delegates"`
+	Delegates              []*DelegateNetConf       `json:"-"`
+	NetStatus              []*NetworkStatus         `json:"-"`
+	Kubeconfig             string                   `json:"kubeconfig"`
+	LogFile                string                   `json:"logFile"`
+	LogLevel               string                   `json:"logLevel"`
+	ReadinessIndicatorFile string                   `json:readinessindicatorfile`
 }
 
 type NetworkStatus struct {


### PR DESCRIPTION
Updates to stable branch based on discussion.

Chiefly omits:

adbea5a fixing readme file version details
a4f5fd4 Add portmap capability support

Also note:

Required modifications to 21cdfe5 resulting in a conflict due to changes in `types.go` likely due to git's difficulty creating a diff in the types due to both changes close to one another, and sweeping changes due to formatting.