### PR TITLE
Fix logFile to match configuration json

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,12 +471,12 @@ Multus will always log via `STDERR`, which is the standard method by which CNI p
 
 ### Writing to a Log File
 
-Optionally, you may have Multus log to a file on the filesystem. This file will be written locally on each node where Multus is executed. You may configure this via the `LogFile` option in the CNI configuration. By default this additional logging to a flat file is disabled.
+Optionally, you may have Multus log to a file on the filesystem. This file will be written locally on each node where Multus is executed. You may configure this via the `logFile` option in the CNI configuration. By default this additional logging to a flat file is disabled.
 
 For example in your CNI configuration, you may set:
 
 ```
-    "LogFile": "/var/log/multus.log",
+    "logFile": "/var/log/multus.log",
 ```
 
 ### Logging Level


### PR DESCRIPTION
The Logging Options section of README describes how to specify a file
to log to.  There is a typo, LogFile should be logFile to match the
json.

Fixes #177

Signed-off-by: Michael Cambria <mcambria@redhat.com>