### PR TITLE
CRD: interfaceRequest -> interface (v1 spec conformance)

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ metadata:
             { "name": "flannel-conf" },
             { "name": "sriov-conf" },
             { "name": "sriov-vlanid-l2enable-conf",
-              "interfaceRequest": "north" }
+              "interface": "north" }
     ]'
 spec:  # specification of the pod's contents
   containers:
@@ -393,7 +393,7 @@ JSON formated network annotation in Pod can have several parameters as following
 
 - namespace: Kubernetes namespace that the target network attach definition is defined in.
 - mac: MAC address (e.g "c2:11:22:33:44:66") for target network interface
-- interfaceRequest: interface name for target network interface
+- interface: interface name for target network interface
 
 Note: If you add `mac`, please add 'tuning' plugin into target network attach definition as CNI plugin chaining as following.
 

--- a/examples/npwg-demo-1/12_pod_case2.yml
+++ b/examples/npwg-demo-1/12_pod_case2.yml
@@ -8,7 +8,7 @@ metadata:
             { "name": "macvlan-conf-2" },
             { "name": "vlan-conf-1-1",
               "namespace": "testns1",
-              "interfaceRequest": "vlan1-1" }
+              "interface": "vlan1-1" }
     ]'
 spec:
   containers:

--- a/multus/multus_test.go
+++ b/multus/multus_test.go
@@ -247,7 +247,7 @@ var _ = Describe("multus operations", func() {
 
 	It("executes delegates with interface name and MAC addr", func() {
 		podNet := `[{"name":"net1",
-	         "interfaceRequest": "test1"},
+	         "interface": "test1"},
 		{"name":"net2",
 		 "mac": "c2:11:22:33:44:66"}
 ]`

--- a/types/types.go
+++ b/types/types.go
@@ -125,7 +125,7 @@ type NetworkSelectionElement struct {
 	MacRequest string `json:"mac,omitempty"`
 	// InterfaceRequest contains an optional requested name for the
 	// network interface this attachment will create in the container
-	InterfaceRequest string `json:"interfaceRequest,omitempty"`
+	InterfaceRequest string `json:"interface,omitempty"`
 }
 
 // K8sArgs is the valid CNI_ARGS used for Kubernetes


### PR DESCRIPTION
Change the Network Attachment Selection Annotation long-form
interface name request JSON key from 'interfaceRequest' to
'interface' to conform with the V1 NPWG spec.

@s1061123 @dougbtv @rkamudhan 