### PR TITLE
Setting the MAC in CNI_ARGS shouldn't override the existing CNI_ARGS

### DIFF
--- a/multus/multus.go
+++ b/multus/multus.go
@@ -178,7 +178,7 @@ func delegateAdd(exec invoke.Exec, ifName string, delegate *types.DelegateNetCon
 			return nil, logging.Errorf("failed to parse mac address %q", delegate.MacRequest)
 		}
 
-		if os.Setenv("CNI_ARGS", fmt.Sprintf("IgnoreUnknown=true;MAC=%s", delegate.MacRequest)) != nil {
+		if os.Setenv("CNI_ARGS",fmt.Sprintf("%s;IgnoreUnknown=true;MAC=%s", os.Getenv("CNI_ARGS"), delegate.MacRequest)) != nil {
 			return nil, logging.Errorf("cannot set %q mac to %q: %v", delegate.Conf.Type, delegate.MacRequest, err)
 		}
 		logging.Debugf("Set MAC address %q to %q", delegate.MacRequest, ifName)


### PR DESCRIPTION
When setting MAC in CNI_ARGS it overrides the existing CNI_ARGS.
This PR changes the code to append the MAC to the existing CNI_ARGS.