### PR TITLE
Travis 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ dist: trusty
 env:
   global:
     - REGISTRY_USER=${REGISTRY_USER}
+    - REGISTRY_PASS=${REGISTRY_PASS}
     - secure: "${REGISTRY_SECURE}"
 
 before_install:
@@ -45,18 +46,29 @@ deploy:
       tags: true
       all_branches: true
       condition: "$TRAVIS_TAG =~ ^v[0-9].*$"
-  # Push images to Dockerhub
+  # Push images to Dockerhub on tag
   - provider: script
     script: >
       bash -c '
       docker tag nfvpe/multus nfvpe/multus:$TRAVIS_TAG;
       docker login -u "$REGISTRY_USER" -p "$REGISTRY_PASS"; 
       docker push nfvpe/multus; 
-      docker push nfvpe/multus:$TRAVIS_TAG'
+      docker push nfvpe/multus:$TRAVIS_TAG;
+      echo foo'
     on:
       tags: true
       all_branches: true
       condition: "$TRAVIS_TAG =~ ^v[0-9].*$"
+  # Push images to Dockerhub on merge to master
+  - provider: script
+    on:
+      branch: master
+    script: >
+      bash -c '
+      docker tag nfvpe/multus nfvpe/multus:snapshot;
+      docker login -u "$REGISTRY_USER" -p "$REGISTRY_PASS";
+      docker push nfvpe/multus:snapshot; 
+      echo foo'
 
 after_success:
   # put build tgz to bintray


### PR DESCRIPTION
Couple changes here: 

* Updates to tag an image as `nfvpe/multus:snapshot` on each pull into master.
* `REGISTRY_PASS` was missing, causing all docker pushes to fail
* Travis CI was parsing the file oddly causing it to [add an N to the end of the script commands in the deployment](https://travis-ci.org/intel/multus-cni/builds/457039193#L1511), worked around it with an echo.

Also thanks to @SchSeba for the pull request looking for this functionality.

fixes #187 