### PR TITLE
Add .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Binary output dir
+bin/
+
+# GOPATH created by the build script
+gopath/
+
+# Test outputs
+*.out
+*.test


### PR DESCRIPTION
Prevent tracking of binary outputs, GOPATH and test outputs.

Signed-off-by: Michal Rostecki <mrostecki@suse.de>