### PR TITLE
k8sclient: Add missing error check

### DIFF
--- a/k8sclient/k8sclient.go
+++ b/k8sclient/k8sclient.go
@@ -568,6 +568,9 @@ func getNetDelegate(client KubeClient, netname string, confdir string) (*types.D
 	if err == nil {
 		if fInfo.IsDir() {
 			files, err := libcni.ConfFiles(netname, []string{".conf", ".conflist"})
+			if err != nil {
+				return nil, err
+			}
 			if len(files) > 0 {
 				var configBytes []byte
 				configBytes, err = getCNIConfigFromFile("", netname)


### PR DESCRIPTION
Before this change, error returned by `libcni.ConfFiles` was
silently ignored.

Signed-off-by: Michal Rostecki <mrostecki@suse.de>