### PR TITLE
Renew release/CI pipeline.

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,22 @@
+# This is an example goreleaser.yaml file with some sane defaults.
+# Make sure to check the documentation at http://goreleaser.com
+builds:
+-  
+  env:
+  - CGO_ENABLED=0
+  main: ./multus/
+  goos:
+  - linux
+  goarch:
+  - 386
+  - amd64
+  - arm
+  - arm64
+archive:
+  wrap_in_directory: true
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ .Tag }}-snapshot"
+release:
+  draft: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,15 @@ language: go
 # for the detail
 # sudo: requried
 dist: trusty
+
+go:
+  - 1.11.x
+
 env:
   global:
     - REGISTRY_USER=${REGISTRY_USER}
     - REGISTRY_PASS=${REGISTRY_PASS}
+    - MULTUS_GOPATH=${PWD}/gopath
     - secure: "${REGISTRY_SECURE}"
 
 before_install:
@@ -17,31 +22,34 @@ install:
   - go get -u golang.org/x/lint/golint
 
 before_script:
-  - golint ./multus/... | grep -v ALL_CAPS | xargs -r false
-  - go fmt ./multus/...
-  - go vet ./multus/...
+  # Make gopath... to run golint/go fmt/go vet
+  - |-
+    if [ ! -h gopath/src/github.com/intel/multus-cni ]; then
+        mkdir -p gopath/src/github.com/intel
+        ln -s ../../../.. gopath/src/github.com/intel/multus-cni || exit 255
+    fi
+  - env GOPATH=${MULTUS_GOPATH} golint gopath/src/github.com/intel/multus-cni/multus/... | grep -v ALL_CAPS | xargs -r false
+  - env GOPATH=${MULTUS_GOPATH} go fmt gopath/src/github.com/intel/multus-cni/...
+  - go tool vet */*.go
 #  - gocyclo -over 15 ./multus
 
 script:
   - ./build
   - sudo ./test.sh
-  - $GOPATH/bin/goveralls  -coverprofile=coverage.out -service=travis-ci
+  - |-
+    GOV_GOPATH=${PWD}/gopath
+    pushd gopath/src/github.com/intel/multus-cni
+    env GOPATH=${GOV_GOPATH} ${GOPATH}/bin/goveralls -coverprofile=coverage.out -service=travis-ci
+    popd
   - mkdir -p ${TRAVIS_BUILD_DIR}/dist
   - tar cvfz ${TRAVIS_BUILD_DIR}/dist/multus-cni_amd64.tar.gz --warning=no-file-changed --exclude="dist" --exclude="vendor" .
   - docker build -t nfvpe/multus .
 
-before_deploy:
-  - go get -u github.com/laher/goxc
-  - mkdir -p $TRAVIS_BUILD_DIR/dist
-  - goxc -d=$TRAVIS_BUILD_DIR/dist -pv=$TRAVIS_TAG -bc=linux -tasks=clean-destination,xc,archive,rmbin
-
 deploy:
-  - provider: releases
-    api_key:
-      secure: "${DEPLOY_SECURE}"
-    file_glob: true
-    file: "$TRAVIS_BUILD_DIR/dist/*/*.gz"
+  # Release on versioned tag (e.g. v1.0)
+  - provider: script
     skip_cleanup: true
+    script: curl -sL https://git.io/goreleaser | bash
     on:
       tags: true
       all_branches: true

--- a/build
+++ b/build
@@ -4,6 +4,20 @@ set -e
 ORG_PATH="github.com/intel"
 REPO_PATH="${ORG_PATH}/multus-cni"
 
+# Add version/commit/date into binary
+# In case of TravisCI, need to check error code of 'git describe'.
+set +e
+git describe --tags --abbrev=0 > /dev/null 2>&1
+if [ "$?" != "0" ]; then
+	VERSION="master"
+else
+	VERSION=$(git describe --tags --abbrev=0)
+fi
+set -e
+DATE=$(date --iso-8601=seconds)
+COMMIT=$(git rev-parse --verify HEAD)
+LDFLAGS="-X main.version=${VERSION:-master} -X main.commit=${COMMIT} -X main.date=${DATE}"
+
 if [ ! -h gopath/src/${REPO_PATH} ]; then
 	mkdir -p gopath/src/${ORG_PATH}
 	ln -s ../../../.. gopath/src/${REPO_PATH} || exit 255
@@ -14,4 +28,4 @@ export GOBIN=${PWD}/bin
 export GOPATH=${PWD}/gopath
 
 echo "Building plugins"
-go install "$@" ${REPO_PATH}/multus
+go install -ldflags "${LDFLAGS}" "$@" ${REPO_PATH}/multus

--- a/multus/multus_test.go
+++ b/multus/multus_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/containernetworking/cni/pkg/skel"
 	cnitypes "github.com/containernetworking/cni/pkg/types"
 	"github.com/containernetworking/cni/pkg/types/020"
-	"github.com/containernetworking/cni/pkg/version"
+	cniversion "github.com/containernetworking/cni/pkg/version"
 	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/containernetworking/plugins/pkg/testutils"
 
@@ -52,7 +52,7 @@ type fakePlugin struct {
 }
 
 type fakeExec struct {
-	version.PluginDecoder
+	cniversion.PluginDecoder
 
 	addIndex int
 	delIndex int


### PR DESCRIPTION
This changes introduce new release/CI pipeline as following:
- Changes cross-compile/deploy tool from goxc to goreleaser
- Fix .travis.yml to run CI in forked repo (see below example)
- Add '-v'/'-version' command to show multus-cni version

example: https://travis-ci.org/s1061123/multus-cni/builds/464208823