### PR TITLE
Pod network extra args

### DIFF
--- a/k8sclient/k8sclient_test.go
+++ b/k8sclient/k8sclient_test.go
@@ -125,8 +125,9 @@ var _ = Describe("k8sclient operations", func() {
 {"name":"net1"},
 {
   "name":"net2",
-  "ipRequest": "1.2.3.4",
-  "macRequest": "aa:bb:cc:dd:ee:ff"
+  "ips": "1.2.3.4",
+  "mac": "aa:bb:cc:dd:ee:ff",
+  "OrgFooBarKeyName": "value"
 },
 {
   "name":"net3",
@@ -167,10 +168,16 @@ var _ = Describe("k8sclient operations", func() {
 		Expect(len(delegates)).To(Equal(3))
 		Expect(delegates[0].Conf.Name).To(Equal("net1"))
 		Expect(delegates[0].Conf.Type).To(Equal("mynet"))
+		Expect(delegates[0].ExtraFields).To(BeEmpty())
 		Expect(delegates[1].Conf.Name).To(Equal("net2"))
 		Expect(delegates[1].Conf.Type).To(Equal("mynet2"))
+		Expect(delegates[1].MacRequest).To(Equal("aa:bb:cc:dd:ee:ff"))
+		Expect(delegates[1].IPRequest).To(Equal("1.2.3.4"))
+		Expect(len(delegates[1].ExtraFields)).To(Equal(1))
+		Expect(delegates[1].ExtraFields["OrgFooBarKeyName"]).To(Equal("value"))
 		Expect(delegates[2].Conf.Name).To(Equal("net3"))
 		Expect(delegates[2].Conf.Type).To(Equal("mynet3"))
+		Expect(delegates[2].ExtraFields).To(BeEmpty())
 	})
 
 	It("fails when the JSON format annotation is invalid", func() {

--- a/multus/multus.go
+++ b/multus/multus.go
@@ -172,7 +172,7 @@ func delegateAdd(exec invoke.Exec, ifName string, delegate *types.DelegateNetCon
 		return nil, logging.Errorf("cannot set %q ifname to %q: %v", delegate.Conf.Type, ifName, err)
 	}
 
-	if delegate.MacRequest != "" || delegate.IPRequest != "" {
+	if delegate.MacRequest != "" || delegate.IPRequest != "" || delegate.ExtraFields != nil {
 		if cniArgs != "" {
 			cniArgs = fmt.Sprintf("%s;IgnoreUnknown=true", cniArgs)
 		} else {
@@ -203,8 +203,23 @@ func delegateAdd(exec invoke.Exec, ifName string, delegate *types.DelegateNetCon
 			cniArgs = fmt.Sprintf("%s;IP=%s", cniArgs, delegate.IPRequest)
 			logging.Debugf("Set IP address %q to %q", delegate.IPRequest, ifName)
 		}
+
+		if delegate.ExtraFields != nil {
+			invalidChars := "; | ="
+			for key, value := range delegate.ExtraFields {
+				if strings.ContainsAny(key, invalidChars) {
+					return nil, logging.Errorf("Key %q contains %q character/s which is invalid", key, invalidChars)
+				}
+				if strings.ContainsAny(value, invalidChars) {
+					return nil, logging.Errorf("Value %q contains %q character/s which is invalid", value, invalidChars)
+				}
+				cniArgs = fmt.Sprintf("%s;%s=%s", cniArgs, key, value)
+				logging.Debugf("Set %q %q to %q", key, value, ifName)
+			}
+		}
+
 		if os.Setenv("CNI_ARGS", cniArgs) != nil {
-			return nil, logging.Errorf("cannot set %q mac to %q and ip to %q", delegate.Conf.Type, delegate.MacRequest, delegate.IPRequest)
+			return nil, logging.Errorf("cannot set %q CNI_ARGS", delegate.Conf.Type)
 		}
 	}
 

--- a/multus/multus_test.go
+++ b/multus/multus_test.go
@@ -251,7 +251,8 @@ var _ = Describe("multus operations", func() {
 			 "ips":"1.2.3.4/24"},
 		{"name":"net2",
 		 "mac": "c2:11:22:33:44:66",
-		 "ips": "10.0.0.1"}
+		 "ips": "10.0.0.1",
+		 "OrgFooBarKeyName": "value"}
 ]`
 		fakePod := testhelpers.NewFakePod("testpod", podNet, "")
 		net1 := `{
@@ -300,7 +301,7 @@ var _ = Describe("multus operations", func() {
 				IP: *testhelpers.EnsureCIDR("1.1.1.3/24"),
 			},
 		}, nil)
-		fExec.addPlugin([]string{"CNI_ARGS=IgnoreUnknown=true;MAC=c2:11:22:33:44:66;IP=10.0.0.1"}, "net2", net2, &types020.Result{
+		fExec.addPlugin([]string{"CNI_ARGS=IgnoreUnknown=true;MAC=c2:11:22:33:44:66;IP=10.0.0.1;OrgFooBarKeyName=value"}, "net2", net2, &types020.Result{
 			CNIVersion: "0.2.0",
 			IP4: &types020.IPConfig{
 				IP: *testhelpers.EnsureCIDR("1.1.1.4/24"),

--- a/types/conf.go
+++ b/types/conf.go
@@ -86,6 +86,9 @@ func LoadDelegateNetConf(bytes []byte, net *NetworkSelectionElement, deviceID st
 		if net.IPRequest != "" {
 			delegateConf.IPRequest = net.IPRequest
 		}
+		if net.ExtraFields != nil {
+			delegateConf.ExtraFields = net.ExtraFields
+		}
 	}
 
 	delegateConf.Bytes = bytes

--- a/types/types.go
+++ b/types/types.go
@@ -74,11 +74,12 @@ type DelegateNetConf struct {
 	ConfList      types.NetConfList
 	IfnameRequest string `json:"ifnameRequest,omitempty"`
 	MacRequest    string `json:"macRequest,omitempty"`
-	IPRequest string `json:"ipRequest,omitempty"`
+	IPRequest     string `json:"ipRequest,omitempty"`
 	// MasterPlugin is only used internal housekeeping
 	MasterPlugin bool `json:"-"`
 	// Conflist plugin is only used internal housekeeping
 	ConfListPlugin bool `json:"-"`
+	ExtraFields map[string]string
 
 	// Raw JSON
 	Bytes []byte
@@ -127,6 +128,10 @@ type NetworkSelectionElement struct {
 	// InterfaceRequest contains an optional requested name for the
 	// network interface this attachment will create in the container
 	InterfaceRequest string `json:"interface,omitempty"`
+	// All key names that do not include a period character are reserved to ensure this specification
+	// may be extended in the future. Keys other than the reserved ones will be stored in the
+	// ExtraFields map
+	ExtraFields      map[string]string
 }
 
 // K8sArgs is the valid CNI_ARGS used for Kubernetes


### PR DESCRIPTION
Support extra keys in pod network annotation

Acorrding to the de-facto standard documentation-
"All key names that do not include a period character are reserved to ensure this specification
may be extended in the future. Implementations that write keys other than those defined in this
specification must use reverse domain name notation (eg "​ org.foo.bar.key-name​ ") to
name the non-standard keys."

This PR extends the NetworkSelectionElement with a key-value map (string->string)
containg the extra, non-stadnard keys passes in the pod network annotation.
(Note - only keys wih a period character are considered as extra keys).

The extra keys and their values are passed to the relevant cni plugin via the CNI_ARGS
environment variable using the following format -
$CNI_ARGS=$CNI_ARGS;key.1=value1;key.2=value2;
