### PR TITLE
Optimize docker image

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,0 +1,20 @@
+# This Dockerfile is used to build the image available on DockerHub
+FROM golang:1.11-alpine AS build
+
+RUN apk add --update bash alpine-sdk
+RUN apk add --update linux-headers
+
+ADD . /usr/src/multus-cni
+
+WORKDIR /usr/src/multus-cni
+
+RUN ./build && file bin/multus
+
+FROM alpine:3.8
+
+RUN apk add --update --no-cache bash
+
+COPY --from=build /usr/src/multus-cni/bin/ /usr/src/multus-cni/bin/
+COPY --from=build /usr/src/multus-cni/images/ /usr/src/multus-cni/images/
+
+ENTRYPOINT /usr/src/multus-cni/images/entrypoint.sh

--- a/build
+++ b/build
@@ -14,4 +14,4 @@ export GOBIN=${PWD}/bin
 export GOPATH=${PWD}/gopath
 
 echo "Building plugins"
-go install "$@" ${REPO_PATH}/multus
+CGO_ENABLED=0 go install -tags netgo "$@" ${REPO_PATH}/multus

--- a/images/entrypoint.sh
+++ b/images/entrypoint.sh
@@ -178,5 +178,7 @@ fi
 
 echo "Entering sleep... (success)"
 
-# Sleep forever.
-sleep infinity
+# Sleep until container is stopped.
+trap : TERM INT
+(while true; do sleep 3600; done) &
+wait


### PR DESCRIPTION
Hello,

I did some optimations of the build process and the docker image:
- ensure that the binary is statically linked (it was dynamically linked against glibc due to the "net" dependency - fortunately there's an easy fix)
- Switch to official golang build image rather than build on rhel or centos
- Use a multi-stage docker build process, so that the final image does not contain any build/compile stuff
- Switch to alpine for the delivered image to further reduce the size
- a small update to entrypoint.sh (use a sleep loop rather than "infinity" because it's not implemented in all sleep variantes; trap container shutdown signals for faster shutdown)

Here are some test builds with this image: https://hub.docker.com/r/micwy/test-multus-portmapping/tags

I was able to reduce the image size from 150MB to 15MB.

If you are fine with that change and default to this Dockerfile, we could reduce the size even more by switching from bash to sh for the entrypoint anduse a bussybox base image.