### PR TITLE
Flannel daemonset remove unused config

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,0 +1,20 @@
+# This Dockerfile is used to build the image available on DockerHub
+FROM golang:1.11-alpine AS build
+
+RUN apk add --update bash alpine-sdk
+RUN apk add --update linux-headers
+
+ADD . /usr/src/multus-cni
+
+WORKDIR /usr/src/multus-cni
+
+RUN ./build && file bin/multus
+
+FROM alpine:3.8
+
+RUN apk add --update --no-cache bash
+
+COPY --from=build /usr/src/multus-cni/bin/ /usr/src/multus-cni/bin/
+COPY --from=build /usr/src/multus-cni/images/ /usr/src/multus-cni/images/
+
+ENTRYPOINT /usr/src/multus-cni/images/entrypoint.sh

--- a/build
+++ b/build
@@ -14,4 +14,4 @@ export GOBIN=${PWD}/bin
 export GOPATH=${PWD}/gopath
 
 echo "Building plugins"
-go install "$@" ${REPO_PATH}/multus
+CGO_ENABLED=0 go install -tags netgo "$@" ${REPO_PATH}/multus

--- a/images/entrypoint.sh
+++ b/images/entrypoint.sh
@@ -178,5 +178,7 @@ fi
 
 echo "Entering sleep... (success)"
 
-# Sleep forever.
-sleep infinity
+# Sleep until container is stopped.
+trap : TERM INT
+(while true; do sleep 3600; done) &
+wait

--- a/images/flannel-daemonset.yml
+++ b/images/flannel-daemonset.yml
@@ -55,25 +55,26 @@ metadata:
     tier: node
     app: flannel
 data:
-  cni-conf.json: |
-    {
-      "name": "cbr0",
-      "plugins": [
-        {
-          "type": "flannel",
-          "delegate": {
-            "hairpinMode": true,
-            "isDefaultGateway": true
-          }
-        },
-        {
-          "type": "portmap",
-          "capabilities": {
-            "portMappings": true
-          }
-        }
-      ]
-    }
+  # ------------------------------- Intentionally removed, Multus daemonset configures /etc/cni/net.d
+  #cni-conf.json: |
+  #  {
+  #    "name": "cbr0",
+  #    "plugins": [
+  #      {
+  #        "type": "flannel",
+  #        "delegate": {
+  #          "hairpinMode": true,
+  #          "isDefaultGateway": true
+  #        }
+  #      },
+  #      {
+  #        "type": "portmap",
+  #        "capabilities": {
+  #          "portMappings": true
+  #        }
+  #      }
+  #    ]
+  #  }
   net-conf.json: |
     {
       "Network": "10.244.0.0/16",


### PR DESCRIPTION
The cni configmap implies that flanell does something with port forwarding. I commented it out to make clear that it has no effect.