### PR TITLE
Remove unused config in flannel-daemonset.yaml

### DIFF
--- a/images/flannel-daemonset.yml
+++ b/images/flannel-daemonset.yml
@@ -55,25 +55,26 @@ metadata:
     tier: node
     app: flannel
 data:
-  cni-conf.json: |
-    {
-      "name": "cbr0",
-      "plugins": [
-        {
-          "type": "flannel",
-          "delegate": {
-            "hairpinMode": true,
-            "isDefaultGateway": true
-          }
-        },
-        {
-          "type": "portmap",
-          "capabilities": {
-            "portMappings": true
-          }
-        }
-      ]
-    }
+  # ------------------------------- Intentionally removed, Multus daemonset configures /etc/cni/net.d
+  #cni-conf.json: |
+  #  {
+  #    "name": "cbr0",
+  #    "plugins": [
+  #      {
+  #        "type": "flannel",
+  #        "delegate": {
+  #          "hairpinMode": true,
+  #          "isDefaultGateway": true
+  #        }
+  #      },
+  #      {
+  #        "type": "portmap",
+  #        "capabilities": {
+  #          "portMappings": true
+  #        }
+  #      }
+  #    ]
+  #  }
   net-conf.json: |
     {
       "Network": "10.244.0.0/16",


### PR DESCRIPTION
The cni configmap implies that flannel does something with port forwarding. I commented it out to make clear that it has no effect.

