### PR TITLE
Fix too restrictive network interface name checking

### DIFF
--- a/k8sclient/k8sclient_test.go
+++ b/k8sclient/k8sclient_test.go
@@ -79,23 +79,21 @@ var _ = Describe("k8sclient operations", func() {
 	})
 
 	It("correctly parses pod network attachment annotation syntax: interface name syntax", func() {
-		ns, net, nif, err := parsePodNetworkObjectName("foonet@nif1/@")
+		ns, net, nif, err := parsePodNetworkObjectName("foonet@ifn@me")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ns).To(Equal(""))
 		Expect(net).To(Equal("foonet"))
-		Expect(nif).To(Equal("nif1/@"))
+		Expect(nif).To(Equal("ifn@me"))
 
-		ns, net, nif, err = parsePodNetworkObjectName("bazns/foonet@nif1/@")
+		ns, net, nif, err = parsePodNetworkObjectName("bazns/foonet@ifn@me")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(ns).To(Equal("bazns"))
 		Expect(net).To(Equal("foonet"))
-		Expect(nif).To(Equal("nif1/@"))
+		Expect(nif).To(Equal("ifn@me"))
 
-		ns, net, nif, err = parsePodNetworkObjectName("baz@ns/foonet@nif1/@")
-		Expect(err).NotTo(HaveOccurred())
-		Expect(ns).To(Equal(""))
-		Expect(net).To(Equal("baz"))
-		Expect(nif).To(Equal("ns/foonet@nif1/@"))
+		ns, net, nif, err = parsePodNetworkObjectName("bazns/foonet@if/name")
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError("Invalid network object (failed at '/')"))
 	})
 
 	It("retrieves delegates from kubernetes using simple format annotation", func() {


### PR DESCRIPTION
Fix too restrictive network interface name checking
  
`parsePodNetworkObjectName()` had too restrictive network interface name checking, trying to enforce RFC 1123 DNS label syntax. However, https://github.com/K8sNetworkPlumbingWG/multi-net-spec/blob/master/%5Bv1%5D%20Kubernetes%20Network%20Custom%20Resource%20Definition%20De-facto%20Standard.md states:

> 4.1.2.1.5 "interface"
>This optional key with value of type string requires the implementation to use the given name for the pod interface resulting from this network attachment. This keys value must be a valid Linux kernel interface name

Fixes #213 and adds tests for correct parsing behavior.