### PR TITLE
Updates entrypoint for atomic move of binary

### DIFF
--- a/images/entrypoint.sh
+++ b/images/entrypoint.sh
@@ -84,8 +84,9 @@ do
   fi
 done
 
-# Copy files into proper places.
-cp -f $MULTUS_BIN_FILE $CNI_BIN_DIR
+# Copy files into place and atomically move into final binary name
+cp -f $MULTUS_BIN_FILE $CNI_BIN_DIR/_multus
+mv -f $CNI_BIN_DIR/_multus $CNI_BIN_DIR/multus 
 if [ "$MULTUS_CONF_FILE" != "auto" ]; then
   cp -f $MULTUS_CONF_FILE $CNI_CONF_DIR
 fi


### PR DESCRIPTION
Theory behind this one is that if we're upgrading Multus using a daemonset, and we copy the file in... During the period where the binary is copied, there's a chance we'll execute a binary that isn't complete.

If instead, we copy the binary to a temporary location and then `mv -f ...` the file to the final location (i.e. to `/opt/cni/bin/multus`) we'll reduce the amount of time where we don't have a valid binary to execute. 