### PR TITLE
Changes configuration for kube api to use protobuf

### DIFF
--- a/k8sclient/k8sclient.go
+++ b/k8sclient/k8sclient.go
@@ -482,6 +482,10 @@ func GetK8sClient(kubeconfig string, kubeClient KubeClient) (KubeClient, error) 
 		return nil, nil
 	}
 
+	// Specify that we use gRPC
+	config.AcceptContentTypes = "application/vnd.kubernetes.protobuf,application/json"
+	config.ContentType = "application/vnd.kubernetes.protobuf"
+
 	// creates the clientset
 	client, err := kubernetes.NewForConfig(config)
 	if err != nil {


### PR DESCRIPTION
Alters the configuration we use to tell Multus to use a gRPC connection to the Kube API as opposed to JSON (which is default)