### PR TITLE
Remove the duplicate condition check in GetPodNetwork function

### DIFF
--- a/k8sclient/k8sclient.go
+++ b/k8sclient/k8sclient.go
@@ -499,10 +499,6 @@ func GetPodNetwork(k8sclient KubeClient, k8sArgs *types.K8sArgs, confdir string,
 		return nil, err
 	}
 
-	if err != nil {
-		return nil, logging.Errorf("GetK8sNetwork: failed to get resourceMap for PodUID: %v %v", podID, err)
-	}
-
 	if len(netAnnot) == 0 {
 		return nil, &NoK8sNetworkError{"no kubernetes network found"}
 	}


### PR DESCRIPTION
Error check has been added twice with unrelated logging
message. As the failed funtion has logged the error, it is
redundant. Removed the duplicate check and log.

Signed-off-by: Saravanan KR <skramaja@redhat.com>