### PR TITLE
Added the option for default network parameters

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -274,3 +274,20 @@ annotations:
  v1.multus-cni.io/default-network: calico-conf
 ...
 ```
+
+### Pass additional parameters to the default cluster network
+
+User may want to pass additional parameters for the default network like mac, ip address, etc...
+
+You are able to do it by passing a map in the default network annotation.
+
+Example:
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+name: pod-example
+annotations:
+ v1.multus-cni.io/default-network: '{"mac":"aa:bb:cc:dd:ee:ff"}'
+...
+```


### PR DESCRIPTION
Added the option for default network parameters.

Example:
```yaml
apiVersion: v1
kind: Pod
metadata:
name: pod-example
annotations:
 v1.multus-cni.io/default-network: '[{"mac":"aa:bb:cc:dd:ee:ff"}]'
```

This will merge the configuration with the master plugins and pass the mac data to it.

This PR also allow to configure 1 addition network

Example:
```yaml
apiVersion: v1
kind: Pod
metadata:
name: pod-example
annotations:
 v1.multus-cni.io/networks: '{"mac":"aa:bb:cc:dd:ee:ff"}'
```

without the slice [].