### PR TITLE
Allows cmdDel to finish if netns doesn't exist

### DIFF
--- a/multus/multus.go
+++ b/multus/multus.go
@@ -402,11 +402,15 @@ func cmdDel(args *skel.CmdArgs, exec invoke.Exec, kubeClient k8s.KubeClient) err
 		// https://github.com/kubernetes/kubernetes/issues/43014#issuecomment-287164444
 		_, ok := err.(ns.NSPathNotExistErr)
 		if ok {
-			return nil
+			logging.Debugf("cmdDel: WARNING netns may not exist, netns: %s, err: %s", netns, err)
+		} else {
+			return fmt.Errorf("failed to open netns %q: %v", netns, err)
 		}
-		return fmt.Errorf("failed to open netns %q: %v", netns, err)
 	}
-	defer netns.Close()
+
+	if netns != nil {
+		defer netns.Close()
+	}
 
 	k8sArgs, err := k8s.GetK8sArgs(args)
 	if err != nil {


### PR DESCRIPTION
More detail in the referenced issue. Generally the gist is that while a pod is in a failed state, the netns that Multus receives doesn't exist and the `cmdDel` function returns prematurely. With the premature return, we don't call the delegates during the delete -- in the case that the delegated CNI plugin needs to perform cleanup functions, this can leave it in a dirty state.

This fix lets the cmdDel continue.

Fixes #267 