### PR TITLE
Add 'verbose' option to logging minimum information

### DIFF
--- a/logging/logging.go
+++ b/logging/logging.go
@@ -29,6 +29,7 @@ type Level uint32
 const (
 	PanicLevel Level = iota
 	ErrorLevel
+	VerboseLevel
 	DebugLevel
 	MaxLevel
 	UnknownLevel
@@ -44,6 +45,8 @@ func (l Level) String() string {
 	switch l {
 	case PanicLevel:
 		return "panic"
+	case VerboseLevel:
+		return "verbose"
 	case ErrorLevel:
 		return "error"
 	case DebugLevel:
@@ -76,6 +79,10 @@ func Debugf(format string, a ...interface{}) {
 	Printf(DebugLevel, format, a...)
 }
 
+func Verbosef(format string, a ...interface{}) {
+	Printf(VerboseLevel, format, a...)
+}
+
 func Errorf(format string, a ...interface{}) error {
 	Printf(ErrorLevel, format, a...)
 	return fmt.Errorf(format, a...)
@@ -88,10 +95,16 @@ func Panicf(format string, a ...interface{}) {
 	Printf(PanicLevel, "========= Stack trace output end ========")
 }
 
-func GetLoggingLevel(levelStr string) Level {
+func GetLoggingLevel() Level {
+	return loggingLevel
+}
+
+func getLoggingLevel(levelStr string) Level {
 	switch strings.ToLower(levelStr) {
 	case "debug":
 		return DebugLevel
+	case "verbose":
+		return VerboseLevel
 	case "error":
 		return ErrorLevel
 	case "panic":
@@ -102,7 +115,7 @@ func GetLoggingLevel(levelStr string) Level {
 }
 
 func SetLogLevel(levelStr string) {
-	level := GetLoggingLevel(levelStr)
+	level := getLoggingLevel(levelStr)
 	if level < MaxLevel {
 		loggingLevel = level
 	}

--- a/logging/logging_test.go
+++ b/logging/logging_test.go
@@ -50,6 +50,8 @@ var _ = Describe("logging operations", func() {
 		Expect(loggingLevel).To(Equal(DebugLevel))
 		SetLogLevel("Error")
 		Expect(loggingLevel).To(Equal(ErrorLevel))
+		SetLogLevel("VERbose")
+		Expect(loggingLevel).To(Equal(VerboseLevel))
 		SetLogLevel("PANIC")
 		Expect(loggingLevel).To(Equal(PanicLevel))
 	})


### PR DESCRIPTION
This change address #274 to add 'verbose option which outputs minimum information (for usual runs with a bit information than 'error').

Following is the example output:
```
2019-02-28T07:08:21Z [verbose] Add: default:pod-case-01:default-cni-network:eth0 {"cniVersion":"0.3.1","interfaces":[{"name":"cni0","mac":"0a:58:0a:f4:02:01"},{"name":"veth49cb42db","mac":"32:2c:67:42:ea:10"},{"name":"eth0","mac":"0a:58:0a:f4:02:03","sandbox":"/proc/23187/ns/net"}],"ips":[{"version":"4","interface":2,"address":"10.244.2.3/24","gateway":"10.244.2.1"}],"routes":[{"dst":"10.244.0.0/16"},{"dst":"0.0.0.0/0","gw":"10.244.2.1"}],"dns":{}}
2019-02-28T07:08:22Z [verbose] Add: default:pod-case-01:vlan-conf-1-1:net1 {"cniVersion":"0.3.0","interfaces":[{"name":"net1","mac":"52:54:00:12:5b:4e","sandbox":"/proc/23187/ns/net"}],"ips":[{"version":"4","interface":0,"address":"172.16.1.101/24"}],"dns":{}}
2019-02-28T07:09:50Z [verbose] Del: default:pod-case-01:vlan-conf-1-1:net1 {"cniVersion":"0.3.0","ipam":{"addresses":[{"address":"172.16.1.101/24"}],"type":"static"},"master":"eth1","name":"vlan-conf-1-1","type":"vlan","vlanid":1}
2019-02-28T07:09:50Z [verbose] Del: default:pod-case-01:default-cni-network:eth0 { "cniVersion": "0.3.1", "name": "default-cni-network", "plugins": [ { "type": "flannel", "name": "flannel.1", "delegate": { "isDefaultGateway": true, "hairpinMode": true } }, { "type": "portmap", "capabilities": { "portMappings": true } } ] }
```