### PR TITLE
Properly initialize kubeClient in SetNetworkStatus method

### DIFF
--- a/k8sclient/k8sclient.go
+++ b/k8sclient/k8sclient.go
@@ -82,17 +82,18 @@ func setKubeClientInfo(c *clientInfo, client KubeClient, k8sArgs *types.K8sArgs)
 }
 
 func SetNetworkStatus(client KubeClient, k8sArgs *types.K8sArgs, netStatus []*types.NetworkStatus, conf *types.NetConf) error {
-	logging.Debugf("SetNetworkStatus: %v, %v, %v", client, k8sArgs, netStatus)
+	logging.Debugf("SetNetworkStatus: %v, %v, %v, %v", client, k8sArgs, netStatus, conf)
 
 	client, err := GetK8sClient(conf.Kubeconfig, client)
 	if err != nil {
-		return err
+		return logging.Errorf("SetNetworkStatus: %v", err)
 	}
 	if client == nil {
 		if len(conf.Delegates) == 0 {
 			// No available kube client and no delegates, we can't do anything
 			return logging.Errorf("must have either Kubernetes config or delegates, refer to Multus documentation for usage instructions")
 		}
+		logging.Debugf("SetNetworkStatus: kube client info is not defined, skip network status setup")
 		return nil
 	}
 

--- a/k8sclient/k8sclient.go
+++ b/k8sclient/k8sclient.go
@@ -91,7 +91,7 @@ func SetNetworkStatus(client KubeClient, k8sArgs *types.K8sArgs, netStatus []*ty
 	if client == nil {
 		if len(conf.Delegates) == 0 {
 			// No available kube client and no delegates, we can't do anything
-			return logging.Errorf("must have either Kubernetes config or delegates, refer Multus README.md for the usage guide")
+			return logging.Errorf("must have either Kubernetes config or delegates, refer to Multus documentation for usage instructions")
 		}
 		return nil
 	}

--- a/k8sclient/k8sclient.go
+++ b/k8sclient/k8sclient.go
@@ -81,9 +81,21 @@ func setKubeClientInfo(c *clientInfo, client KubeClient, k8sArgs *types.K8sArgs)
 	c.Podname = string(k8sArgs.K8S_POD_NAME)
 }
 
-func SetNetworkStatus(client KubeClient, k8sArgs *types.K8sArgs, netStatus []*types.NetworkStatus) error {
-
+func SetNetworkStatus(client KubeClient, k8sArgs *types.K8sArgs, netStatus []*types.NetworkStatus, conf *types.NetConf) error {
 	logging.Debugf("SetNetworkStatus: %v, %v, %v", client, k8sArgs, netStatus)
+
+	client, err := GetK8sClient(conf.Kubeconfig, client)
+	if err != nil {
+		return err
+	}
+	if client == nil {
+		if len(conf.Delegates) == 0 {
+			// No available kube client and no delegates, we can't do anything
+			return logging.Errorf("must have either Kubernetes config or delegates, refer Multus README.md for the usage guide")
+		}
+		return nil
+	}
+
 	podName := string(k8sArgs.K8S_POD_NAME)
 	podNamespace := string(k8sArgs.K8S_POD_NAMESPACE)
 	pod, err := client.GetPod(podNamespace, podName)

--- a/multus/multus.go
+++ b/multus/multus.go
@@ -486,7 +486,7 @@ func cmdDel(args *skel.CmdArgs, exec invoke.Exec, kubeClient k8s.KubeClient) err
 	// unset the network status annotation in apiserver, only in case Multus as kubeconfig
 	if in.Kubeconfig != "" {
 		if !types.CheckSystemNamespaces(string(k8sArgs.K8S_POD_NAMESPACE), in.SystemNamespaces) {
-			err := k8s.SetNetworkStatus(kubeClient, k8sArgs, nil, n)
+			err := k8s.SetNetworkStatus(kubeClient, k8sArgs, nil, in)
 			if err != nil {
 				// error happen but continue to delete
 				logging.Errorf("Multus: Err unset the networks status: %v", err)

--- a/multus/multus.go
+++ b/multus/multus.go
@@ -393,7 +393,7 @@ func cmdAdd(args *skel.CmdArgs, exec invoke.Exec, kubeClient k8s.KubeClient) (cn
 	//set the network status annotation in apiserver, only in case Multus as kubeconfig
 	if n.Kubeconfig != "" && kc != nil {
 		if !types.CheckSystemNamespaces(kc.Podnamespace, n.SystemNamespaces) {
-			err = k8s.SetNetworkStatus(kubeClient, k8sArgs, netStatus)
+			err = k8s.SetNetworkStatus(kubeClient, k8sArgs, netStatus, n)
 			if err != nil {
 				return nil, logging.Errorf("Multus: Err set the networks status: %v", err)
 			}
@@ -486,7 +486,7 @@ func cmdDel(args *skel.CmdArgs, exec invoke.Exec, kubeClient k8s.KubeClient) err
 	// unset the network status annotation in apiserver, only in case Multus as kubeconfig
 	if in.Kubeconfig != "" {
 		if !types.CheckSystemNamespaces(string(k8sArgs.K8S_POD_NAMESPACE), in.SystemNamespaces) {
-			err := k8s.SetNetworkStatus(kubeClient, k8sArgs, nil)
+			err := k8s.SetNetworkStatus(kubeClient, k8sArgs, nil, n)
 			if err != nil {
 				// error happen but continue to delete
 				logging.Errorf("Multus: Err unset the networks status: %v", err)


### PR DESCRIPTION
Properly set k8sclient before quiring pod information in SetNetworkStatus method.
k8sclient has a nul value when multus calls SetNetworkStatus method which leads to the runtime panic.

Fixes https://github.com/intel/multus-cni/issues/281