### PR TITLE
Fix issue we the SetNetworkStatus function the kubeclient is null

### DIFF
--- a/multus/multus.go
+++ b/multus/multus.go
@@ -393,7 +393,7 @@ func cmdAdd(args *skel.CmdArgs, exec invoke.Exec, kubeClient k8s.KubeClient) (cn
 	//set the network status annotation in apiserver, only in case Multus as kubeconfig
 	if n.Kubeconfig != "" && kc != nil {
 		if !types.CheckSystemNamespaces(kc.Podnamespace, n.SystemNamespaces) {
-			err = k8s.SetNetworkStatus(kubeClient, k8sArgs, netStatus)
+			err = k8s.SetNetworkStatus(kubeClient, n, k8sArgs, netStatus)
 			if err != nil {
 				return nil, logging.Errorf("Multus: Err set the networks status: %v", err)
 			}
@@ -486,7 +486,7 @@ func cmdDel(args *skel.CmdArgs, exec invoke.Exec, kubeClient k8s.KubeClient) err
 	// unset the network status annotation in apiserver, only in case Multus as kubeconfig
 	if in.Kubeconfig != "" {
 		if !types.CheckSystemNamespaces(string(k8sArgs.K8S_POD_NAMESPACE), in.SystemNamespaces) {
-			err := k8s.SetNetworkStatus(kubeClient, k8sArgs, nil)
+			err := k8s.SetNetworkStatus(kubeClient, in, k8sArgs, nil)
 			if err != nil {
 				// error happen but continue to delete
 				logging.Errorf("Multus: Err unset the networks status: %v", err)


### PR DESCRIPTION
when we pass the kubeclient(interface type) and run the GetK8sClient(conf.Kubeconfig, kubeClient)
this is not reflected in the kubeclient object after we finnish the related function

the solution is to run also run the GetK8sClient also inside the SetNetworkStatus function

Related to issue https://github.com/intel/multus-cni/issues/281

I think the issue was introduce here https://github.com/intel/multus-cni/commit/5dc774a5471acfa8a6c43deb4750ff4730ce1fc0#diff-1a409ce08104667a3288dace284c289a