### PR TITLE
Updates image tagging / adds version tagged images to Daemonsets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,8 +59,10 @@ deploy:
     script: >
       bash -c '
       docker tag nfvpe/multus nfvpe/multus:$TRAVIS_TAG;
+      docker tag nfvpe/multus nfvpe/multus:stable;
       docker login -u "$REGISTRY_USER" -p "$REGISTRY_PASS"; 
-      docker push nfvpe/multus; 
+      docker push nfvpe/multus;
+      docker push nfvpe/multus:stable;
       docker push nfvpe/multus:$TRAVIS_TAG;
       echo foo'
     on:
@@ -75,7 +77,8 @@ deploy:
       bash -c '
       docker tag nfvpe/multus nfvpe/multus:snapshot;
       docker login -u "$REGISTRY_USER" -p "$REGISTRY_PASS";
-      docker push nfvpe/multus:snapshot; 
+      docker push nfvpe/multus:snapshot;
+      docker push nfvpe/multus:latest;
       echo foo'
 
 after_success:

--- a/images/multus-crio-daemonset.yml
+++ b/images/multus-crio-daemonset.yml
@@ -130,7 +130,7 @@ spec:
       serviceAccountName: multus
       containers:
       - name: kube-multus
-        image: nfvpe/multus:latest
+        image: nfvpe/multus:v3.2
         command: ["/entrypoint.sh"]
         args:
         - "--multus-conf-file=/tmp/multus-conf/70-multus.conf"

--- a/images/multus-daemonset.yml
+++ b/images/multus-daemonset.yml
@@ -130,7 +130,7 @@ spec:
       serviceAccountName: multus
       containers:
       - name: kube-multus
-        image: nfvpe/multus:latest
+        image: nfvpe/multus:v3.2
         command: ["/entrypoint.sh"]
         args:
         - "--multus-conf-file=/tmp/multus-conf/70-multus.conf"


### PR DESCRIPTION
This PR updates our image tagging scheme, now the `:latest` tagged image will be equivalent to `:snapshot` (we keep snapshot for historical reasons, but, both `:latest` and `:snapshot` will now be the builds from the tip of master)

In order to retain stability for users -- this also updates the daemonsets to point at a tagged release image -- in this case, it anticipates the `:v3.2` tag.

In preparation for this, and before the release v3.2 is tagged -- I have tagged a v3.2 release image so we can merge this now before we officially tag. So that users aren't stuck with a daemonset that can't pull an image. That image tag will be overwritten when we make the tag. (image tags viewable here: https://hub.docker.com/r/nfvpe/multus/tags)

Fixes #260 