### PR TITLE
Enable Rolling Update on defined DaemonSets

### DIFF
--- a/examples/multus-with-flannel.yml
+++ b/examples/multus-with-flannel.yml
@@ -91,6 +91,8 @@ metadata:
     tier: node
     app: multus
 spec:
+  updateStrategy:
+    type: RollingUpdate
   template:
     metadata:
       labels:

--- a/examples/npwg-demo-1/06_flannel2.yml
+++ b/examples/npwg-demo-1/06_flannel2.yml
@@ -117,6 +117,8 @@ metadata:
     tier: node
     app: flannel2
 spec:
+  updateStrategy:
+    type: RollingUpdate
   template:
     metadata:
       labels:

--- a/images/flannel-daemonset.yml
+++ b/images/flannel-daemonset.yml
@@ -92,6 +92,8 @@ metadata:
     tier: node
     app: flannel
 spec:
+  updateStrategy:
+    type: RollingUpdate
   template:
     metadata:
       labels:

--- a/images/multus-crio-daemonset.yml
+++ b/images/multus-crio-daemonset.yml
@@ -115,6 +115,8 @@ metadata:
     tier: node
     app: multus
 spec:
+  updateStrategy:
+    type: RollingUpdate
   template:
     metadata:
       labels:

--- a/images/multus-daemonset.yml
+++ b/images/multus-daemonset.yml
@@ -115,6 +115,8 @@ metadata:
     tier: node
     app: multus
 spec:
+  updateStrategy:
+    type: RollingUpdate
   template:
     metadata:
       labels:


### PR DESCRIPTION
With RollingUpdate update strategy, after you update a DaemonSet template, old DaemonSet pods will be killed, and new DaemonSet pods will be created automatically, in a controlled fashion.

I added this configuration in order to deal with updates automatically at the moment of updating multus/etc docker image version in running DaemonSets