### PR TITLE
Add pod cidr indication in quickstart doc

### DIFF
--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -34,7 +34,7 @@ If the runtime is cri-o, then apply these files.
 $ cat ./images/{multus-crio-daemonset.yml,flannel-daemonset.yml} | kubectl apply -f -
 ```
 
-NOTE: The pod cidr in flannel-daemonset.yml is 10.244.0.0/16. You have to specify `--pod-network-cidr=10.244.0.0/16` if you use kubeadm to install kubernetes
+**NOTE**: The pod cidr in flannel-daemonset.yml is 10.244.0.0/16. If you're using `kubeadm` to install Kubernetes, you may have to specify `--pod-network-cidr=10.244.0.0/16` as a parameter to `kubeadm init`.
 ### Validating your installation
 
 Generally, the first step in validating your installation is to look at the `STATUS` field of your nodes, you can check it out by looking at:

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -33,6 +33,8 @@ If the runtime is cri-o, then apply these files.
 ```
 $ cat ./images/{multus-crio-daemonset.yml,flannel-daemonset.yml} | kubectl apply -f -
 ```
+
+NOTE: The pod cidr in flannel-daemonset.yml is 10.244.0.0/16. You have to specify `--pod-network-cidr=10.244.0.0/16` if you use kubeadm to install kubernetes
 ### Validating your installation
 
 Generally, the first step in validating your installation is to look at the `STATUS` field of your nodes, you can check it out by looking at:


### PR DESCRIPTION
The flannel yaml in the example is using 10.244.0.0/16. If user bootstraps
a k8s cluster with different pod cidr, pod traffic will not go thru the flannel
vxlan tunnel.