### PR TITLE
[build] Adds CGO_ENABLED=0 and -tags no_openssl to build script

### DIFF
--- a/build
+++ b/build
@@ -26,6 +26,7 @@ fi
 export GO15VENDOREXPERIMENT=1
 export GOBIN=${PWD}/bin
 export GOPATH=${PWD}/gopath
+export CGO_ENABLED=0
 
 echo "Building plugins"
-go install -ldflags "${LDFLAGS}" "$@" ${REPO_PATH}/multus
+go install -tags no_openssl -ldflags "${LDFLAGS}" "$@" ${REPO_PATH}/multus


### PR DESCRIPTION
* `CGO_ENABLED=0` will create statically linked binaries (nice for the go binary running on the host machine and not in the container as is the case with Multus)
* `-tags no_openssl` will use the Go compiler's native cryptography without a reliance on OpenSSL.