### PR TITLE
assign device id to pciBusID in delegated config

### DIFF
--- a/types/conf.go
+++ b/types/conf.go
@@ -273,6 +273,7 @@ func delegateAddDeviceID(inBytes []byte, deviceID string) ([]byte, error) {
 	}
 	// Inject deviceID
 	rawConfig["deviceID"] = deviceID
+	rawConfig["pciBusID"] = deviceID
 	configBytes, err := json.Marshal(rawConfig)
 	if err != nil {
 		return nil, logging.Errorf("delegateAddDeviceID: failed to re-marshal Spec.Config: %v", err)
@@ -307,6 +308,7 @@ func addDeviceIDInConfList(inBytes []byte, deviceID string) ([]byte, error) {
 	}
 	// Inject deviceID
 	firstPlugin["deviceID"] = deviceID
+	firstPlugin["pciBusID"] = deviceID
 
 	configBytes, err := json.Marshal(rawConfig)
 	if err != nil {

--- a/types/conf_test.go
+++ b/types/conf_test.go
@@ -16,6 +16,7 @@
 package types
 
 import (
+	"encoding/json"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -129,6 +130,96 @@ var _ = Describe("config operations", func() {
 		Expect(b1).To(Equal(true))
 		b2 := CheckSystemNamespaces("foobar1", []string{"barfoo", "bafoo", "foobar"})
 		Expect(b2).To(Equal(false))
+	})
+
+	It("assigns deviceID in delegated conf", func() {
+		conf := `{
+    "name": "second-network",
+    "type": "sriov"
+}`
+		type sriovNetConf struct {
+			Name     string `json:"name"`
+			Type     string `json:"type"`
+			DeviceID string `json:"deviceID"`
+		}
+		sriovConf := &sriovNetConf{}
+		delegateNetConf, err := LoadDelegateNetConf([]byte(conf), nil, "0000:00:00.0")
+		Expect(err).NotTo(HaveOccurred())
+
+		err = json.Unmarshal(delegateNetConf.Bytes, &sriovConf)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(sriovConf.DeviceID).To(Equal("0000:00:00.0"))
+	})
+
+	It("assigns deviceID in delegated conf list", func() {
+		conf := `{
+    "name": "second-network",
+    "plugins": [
+      {
+        "type": "sriov"
+      }
+    ]
+}`
+		type sriovNetConf struct {
+			Name     string `json:"name"`
+			Type     string `json:"type"`
+			DeviceID string `json:"deviceID"`
+		}
+		type sriovNetConfList struct {
+			Plugins []*sriovNetConf `json:"plugins"`
+		}
+		sriovConfList := &sriovNetConfList{}
+		delegateNetConf, err := LoadDelegateNetConf([]byte(conf), nil, "0000:00:00.1")
+		Expect(err).NotTo(HaveOccurred())
+
+		err = json.Unmarshal(delegateNetConf.Bytes, &sriovConfList)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(sriovConfList.Plugins[0].DeviceID).To(Equal("0000:00:00.1"))
+	})
+
+	It("assigns pciBusID in delegated conf", func() {
+		conf := `{
+    "name": "second-network",
+    "type": "host-device"
+}`
+		type hostDeviceNetConf struct {
+			Name     string `json:"name"`
+			Type     string `json:"type"`
+			PCIBusID string `json:"pciBusID"`
+		}
+		hostDeviceConf := &hostDeviceNetConf{}
+		delegateNetConf, err := LoadDelegateNetConf([]byte(conf), nil, "0000:00:00.2")
+		Expect(err).NotTo(HaveOccurred())
+
+		err = json.Unmarshal(delegateNetConf.Bytes, &hostDeviceConf)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(hostDeviceConf.PCIBusID).To(Equal("0000:00:00.2"))
+	})
+
+	It("assigns pciBusID in delegated conf list", func() {
+		conf := `{
+    "name": "second-network",
+    "plugins": [
+      {
+        "type": "host-device"
+      }
+    ]
+}`
+		type hostDeviceNetConf struct {
+			Name     string `json:"name"`
+			Type     string `json:"type"`
+			PCIBusID string `json:"pciBusID"`
+		}
+		type hostDeviceNetConfList struct {
+			Plugins []*hostDeviceNetConf `json:"plugins"`
+		}
+		hostDeviceConfList := &hostDeviceNetConfList{}
+		delegateNetConf, err := LoadDelegateNetConf([]byte(conf), nil, "0000:00:00.3")
+		Expect(err).NotTo(HaveOccurred())
+
+		err = json.Unmarshal(delegateNetConf.Bytes, &hostDeviceConfList)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(hostDeviceConfList.Plugins[0].PCIBusID).To(Equal("0000:00:00.3"))
 	})
 
 })


### PR DESCRIPTION
This allows host-device plugin to recognize
Device PCI address passed from Multus.
It is related to the change in host-device which
enables use of device pci address as a config option:
https://github.com/containernetworking/plugins/pull/300