### PR TITLE
entrypoint.sh: add timestamps to log messages; log autogenerated config file

### DIFF
--- a/images/entrypoint.sh
+++ b/images/entrypoint.sh
@@ -35,6 +35,21 @@ function usage()
     echo -e "\t--multus-log-file=$MULTUS_LOG_FILE (empty by default, used only with --multus-conf-file=auto)"
 }
 
+function log()
+{
+    echo "$(date --iso-8601=seconds) ${1}"
+}
+
+function error()
+{
+    log "ERR:  {$1}"
+}
+
+function warn()
+{
+    log "WARN: {$1}"
+}
+
 # Parse parameters given as arguments to this script.
 while [ "$1" != "" ]; do
     PARAM=`echo $1 | awk -F= '{print $1}'`
@@ -69,7 +84,7 @@ while [ "$1" != "" ]; do
             MULTUS_LOG_FILE=$VALUE
             ;;
         *)
-            echo "WARNING: unknown parameter \"$PARAM\""
+            warn "unknown parameter \"$PARAM\""
             ;;
     esac
     shift
@@ -87,7 +102,7 @@ fi
 for i in "${arr[@]}"
 do
   if [ ! -e "$i" ]; then
-    echo "Location $i does not exist"
+    warn "Location $i does not exist"
     exit 1;
   fi
 done
@@ -116,10 +131,10 @@ SKIP_TLS_VERIFY=${SKIP_TLS_VERIFY:-false}
 if [ -f "$SERVICE_ACCOUNT_PATH/token" ]; then
   # We're running as a k8d pod - expect some variables.
   if [ -z ${KUBERNETES_SERVICE_HOST} ]; then
-    echo "KUBERNETES_SERVICE_HOST not set"; exit 1;
+    error "KUBERNETES_SERVICE_HOST not set"; exit 1;
   fi
   if [ -z ${KUBERNETES_SERVICE_PORT} ]; then
-    echo "KUBERNETES_SERVICE_PORT not set"; exit 1;
+    error "KUBERNETES_SERVICE_PORT not set"; exit 1;
   fi
 
   if [ "$SKIP_TLS_VERIFY" == "true" ]; then
@@ -156,7 +171,7 @@ current-context: multus-context
 EOF
 
 else
-  echo "WARNING: Doesn't look like we're running in a kubernetes environment (no serviceaccount token)"
+  warn "Doesn't look like we're running in a kubernetes environment (no serviceaccount token)"
 fi
 
 # ---------------------- end Generate a "kube-config".
@@ -164,7 +179,7 @@ fi
 # ------------------------------- Generate "00-multus.conf"
 
 if [ "$MULTUS_CONF_FILE" == "auto" ]; then
-  echo "Generating Multus configuration file ..."
+  log "Generating Multus configuration file ..."
   found_master=false
   tries=0
   while [ $found_master == false ]; do
@@ -172,12 +187,12 @@ if [ "$MULTUS_CONF_FILE" == "auto" ]; then
     if [ "$MASTER_PLUGIN" == "" ]; then
       if [ $tries -lt 600 ]; then
         if ! (($tries % 5)); then
-          echo "Attemping to find master plugin configuration, attempt $tries"
+          log "Attemping to find master plugin configuration, attempt $tries"
         fi
         let "tries+=1"
         sleep 1;
       else
-        echo "Error: Multus could not be configured: no master plugin was found."
+        error "Multus could not be configured: no master plugin was found."
         exit 1;
       fi
     else
@@ -201,7 +216,7 @@ if [ "$MULTUS_CONF_FILE" == "auto" ]; then
           verbose)
               ;;
           *)
-              echo "ERROR: Log levels should be one of: debug/verbose/error/panic, did not understand $MULTUS_LOG_LEVEL"
+              error "Log levels should be one of: debug/verbose/error/panic, did not understand $MULTUS_LOG_LEVEL"
               usage
               exit 1     
         esac
@@ -229,14 +244,15 @@ if [ "$MULTUS_CONF_FILE" == "auto" ]; then
 EOF
   		)
       echo $CONF > $CNI_CONF_DIR/00-multus.conf
-      echo "Config file created @ $CNI_CONF_DIR/00-multus.conf"
+      log "Config file created @ $CNI_CONF_DIR/00-multus.conf"
+      echo $CONF
     fi
   done
 fi
 
 # ---------------------- end Generate "00-multus.conf".
 
-echo "Entering sleep... (success)"
+log "Entering sleep... (success)"
 
 # Sleep forever.
 sleep infinity


### PR DESCRIPTION
Example:

```
2019-05-09T15:41:20-05:00 Generating Multus configuration file ...
2019-05-09T15:41:20-05:00 Attemping to find master plugin configuration, attempt 0
2019-05-09T15:41:20-05:00 Attemping to find master plugin configuration, attempt 1
2019-05-09T15:41:20-05:00 Attemping to find master plugin configuration, attempt 10
2019-05-09T15:41:20-05:00 Attemping to find master plugin configuration, attempt 15
2019-05-09T15:41:20-05:00 Attemping to find master plugin configuration, attempt 20
2019-05-09T15:41:20-05:00 Config file created @ /host/etc/cni/net.d/00-multus.conf
{ "name": "multus-cni-network", "type": "multus", "namespaceIsolation": true, "logLevel": "verbose", "kubeconfig": "/etc/kubernetes/cni/net.d/multus.d/multus.kubeconfig", "delegates": [ { "cniVersion": "0.3.1", "name": "openshift-sdn", "type": "openshift-sdn" } ] }
2019-05-09T15:41:20-05:00 Entering sleep... (success)
```

@dougbtv @s1061123 @rkamudhan 