### PR TITLE
Continue to process cmdDel() in case of no network namespace

### DIFF
--- a/multus/multus.go
+++ b/multus/multus.go
@@ -417,14 +417,10 @@ func cmdGet(args *skel.CmdArgs, exec invoke.Exec, kubeClient k8s.KubeClient) (cn
 }
 
 func cmdDel(args *skel.CmdArgs, exec invoke.Exec, kubeClient k8s.KubeClient) error {
-	in, err := types.LoadNetConf(args.StdinData)
 	logging.Debugf("cmdDel: %v, %v, %v", args, exec, kubeClient)
+	in, err := types.LoadNetConf(args.StdinData)
 	if err != nil {
 		return err
-	}
-
-	if args.Netns == "" {
-		return nil
 	}
 
 	netnsfound := true
@@ -436,7 +432,7 @@ func cmdDel(args *skel.CmdArgs, exec invoke.Exec, kubeClient k8s.KubeClient) err
 		_, ok := err.(ns.NSPathNotExistErr)
 		if ok {
 			netnsfound = false
-			logging.Debugf("cmdDel: WARNING netns may not exist, netns: %s, err: %s", netns, err)
+			logging.Debugf("cmdDel: WARNING netns may not exist, netns: %s, err: %s", args.Netns, err)
 		} else {
 			return fmt.Errorf("failed to open netns %q: %v", netns, err)
 		}


### PR DESCRIPTION
K8s with docker runtime, cmdDel() is invoked with empty network
namespace in case of restart node. Currently multus just returns
but CNI spec mention that we should invoke CNI plugin to cleanup.

This PR deletes "return nil" and proceeds to invoke CNI plugins
DEL. Fix #323.