### PR TITLE
CNIVersion fix for conflist

### DIFF
--- a/doc/how-to-use.md
+++ b/doc/how-to-use.md
@@ -530,5 +530,7 @@ Used only with `--multus-conf-file=auto`. Allows you to specify an alternate pat
 
 Used only with `--multus-conf-file=auto`. See the documentation for logging for which values are permitted.
 
+Used only with `--multus-conf-file=auto`. Allows you to specify CNI spec version. Please set if you need to speicfy CNI spec version.
 
+    --cni-version=
 

--- a/images/entrypoint.sh
+++ b/images/entrypoint.sh
@@ -61,6 +61,9 @@ while [ "$1" != "" ]; do
             usage
             exit
             ;;
+        --cni-version)
+            CNI_VERSION=$VALUE
+            ;;
         --cni-conf-dir)
             CNI_CONF_DIR=$VALUE
             ;;
@@ -233,9 +236,15 @@ if [ "$MULTUS_CONF_FILE" == "auto" ]; then
         LOG_FILE_STRING="\"logFile\": \"$MULTUS_LOG_FILE\","
       fi
 
+      CNI_VERSION_STRING=""
+      if [ ! -z "${CNI_VERSION// }" ]; then
+        CNI_VERSION_STRING="\"cniVersion\": \"$CNI_VERSION\","
+      fi
+
       MASTER_PLUGIN_JSON="$(cat $MULTUS_AUTOCONF_DIR/$MASTER_PLUGIN)"
       CONF=$(cat <<-EOF
   			{
+          $CNI_VERSION_STRING
   				"name": "multus-cni-network",
   				"type": "multus",
           $ISOLATION_STRING

--- a/multus/multus.go
+++ b/multus/multus.go
@@ -493,6 +493,14 @@ func cmdDel(args *skel.CmdArgs, exec invoke.Exec, kubeClient k8s.KubeClient) err
 		in.Delegates[0].MasterPlugin = true
 	}
 
+	// set CNIVersion in delegate CNI config if there is no CNIVersion and multus conf have CNIVersion.
+	for _, v := range in.Delegates {
+		if v.ConfListPlugin == true && v.ConfList.CNIVersion == "" && in.CNIVersion != "" {
+			v.ConfList.CNIVersion = in.CNIVersion
+			v.Bytes, err = json.Marshal(v.ConfList)
+		}
+	}
+
 	// unset the network status annotation in apiserver, only in case Multus as kubeconfig
 	if in.Kubeconfig != "" {
 		if netnsfound {


### PR DESCRIPTION
This change introduces two fix about CNIVersion. One is to add CNIVersion into
delegated CNI conflist in case of DEL if CNIVersion is missing. ParseVersion() in libcni
checks cniVersion as mandatory field and sometimes user/daemonset miss it.
The latest flannel daemonset yaml (of flannel github) does not have CNIVersion, for example.
This change adds CNIVersion from multus config if cniVersion is missing (empty) in delegated
CNI config.

In addition, this fix also adds '--cni-version' in entrypoint.sh to add cniVersion in multus
config in case of '--multus-conf-file=auto'.