### PR TITLE
[entrypoint] Adds script parameter to optionally rename source CNI with .old

### DIFF
--- a/doc/how-to-use.md
+++ b/doc/how-to-use.md
@@ -541,3 +541,7 @@ In some cases, the original CNI configuration that the Multus configuration was 
 When using CRIO, you may need to restart CRIO to get the Multus configuration file to take -- this is rarely necessary.
 
     --restart-crio=false
+
+Additionally when using CRIO, you may wish to have the CNI config file that's used as the source for `--multus-conf-file=auto` renamed. This boolean option when set to true automatically renames the file with a `.old` suffix to the original filename.
+
+    --rename-conf-file=true

--- a/images/entrypoint.sh
+++ b/images/entrypoint.sh
@@ -31,6 +31,7 @@ OVERRIDE_NETWORK_NAME=false
 MULTUS_CLEANUP_CONFIG_ON_EXIT=false
 RESTART_CRIO=false
 CRIO_RESTARTED_ONCE=false
+RENAME_SOURCE_CONFIG_FILE=false
 
 # Give help text for parameters.
 function usage()
@@ -56,6 +57,7 @@ function usage()
     echo -e "\t--multus-log-file=$MULTUS_LOG_FILE (empty by default, used only with --multus-conf-file=auto)"
     echo -e "\t--override-network-name=false (used only with --multus-conf-file=auto)"
     echo -e "\t--cleanup-config-on-exit=false (used only with --multus-conf-file=auto)"
+    echo -e "\t--rename-conf-file=false (used only with --multus-conf-file=auto)"
     echo -e "\t--restart-crio=false (restarts CRIO after config file is generated)"
 }
 
@@ -121,6 +123,9 @@ while [ "$1" != "" ]; do
             ;;
         --restart-crio)
             RESTART_CRIO=$VALUE
+            ;;
+        --rename-conf-file)
+            RENAME_SOURCE_CONFIG_FILE=$VALUE
             ;;
         *)
             warn "unknown parameter \"$PARAM\""
@@ -310,7 +315,7 @@ EOF
       echo $CONF
       
       # If we're not performing the cleanup on exit, we can safely rename the config file.
-      if [ "$MULTUS_CLEANUP_CONFIG_ON_EXIT" == false ]; then
+      if [ "$RENAME_SOURCE_CONFIG_FILE" == true ]; then
         mv ${MULTUS_AUTOCONF_DIR}/${MASTER_PLUGIN} ${MULTUS_AUTOCONF_DIR}/${MASTER_PLUGIN}.old
         log "Original master file moved to ${MULTUS_AUTOCONF_DIR}/${MASTER_PLUGIN}.old"
       fi

--- a/images/multus-daemonset-crio.yml
+++ b/images/multus-daemonset-crio.yml
@@ -141,6 +141,7 @@ spec:
         - "--cni-bin-dir=/host/usr/libexec/cni"
         - "--multus-conf-file=auto"
         - "--override-network-name=true"
+        - "--rename-conf-file=true"
         resources:
           requests:
             cpu: "100m"


### PR DESCRIPTION
When using CRIO, you may wish to have the CNI config file that's used as the source for `--multus-conf-file=auto` renamed. This boolean option when set to true automatically renames the file with a `.old` suffix to the original filename.

Adds new option:

```
--rename-conf-file=true
```

Includes docs and addition to the CRIO daemonset.

Tomo has also recently noted, and I agree -- that the number of options is expanding rapidly, and we are incurring some overhead in having the entrypoint be a bash script. For future consideration.