### PR TITLE
Use ENV GO111MODULE=off when building from openshift/origin-release:golang-1.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,7 @@ script:
       tar cvfz ${TRAVIS_BUILD_DIR}/dist/multus-cni_amd64.tar.gz --warning=no-file-changed --exclude="dist" .
       docker build -t nfvpe/multus:latest-amd64 .
       docker build -t nfvpe/multus:latest-ppc64le -f Dockerfile.ppc64le .
+      docker build -t nfvpe/multus-origin:latest -f Dockerfile.openshift .
     fi
 
 deploy:

--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -4,11 +4,11 @@ FROM openshift/origin-release:golang-1.10 as builder
 ADD . /usr/src/multus-cni
 
 WORKDIR /usr/src/multus-cni
+ENV GO111MODULE=off
 RUN ./build
 
 FROM openshift/origin-base
 RUN mkdir -p /usr/src/multus-cni/images && mkdir -p /usr/src/multus-cni/bin
-COPY --from=builder /usr/src/multus-cni/images/70-multus.conf /usr/src/multus-cni/images
 COPY --from=builder /usr/src/multus-cni/bin/multus /usr/src/multus-cni/bin
 ADD ./images/entrypoint.sh /
 


### PR DESCRIPTION
Updates the `Dockerfile.openshift` to use `ENV GO111MODULE=off`

Additionally, adds a build from the Dockerfile.openshift to the travis build so that we get some feedback if it breaks (which it unfortunately did with #368)