### PR TITLE
Appends binDir to CNI_PATH 

### DIFF
--- a/multus/multus.go
+++ b/multus/multus.go
@@ -238,7 +238,10 @@ func delegateAdd(exec invoke.Exec, ifName string, delegate *types.DelegateNetCon
 			return nil, logging.Errorf("Multus: error in invoke Conflist add - %q: %v", delegate.ConfList.Name, err)
 		}
 	} else {
+		origpath := os.Getenv("CNI_PATH")
+		os.Setenv("CNI_PATH", origpath+":"+binDir)
 		result, err = invoke.DelegateAdd(context.Background(), delegate.Conf.Type, delegate.Bytes, exec)
+		os.Setenv("CNI_PATH", origpath)
 		if err != nil {
 			return nil, logging.Errorf("Multus: error in invoke Delegate add - %q: %v", delegate.Conf.Type, err)
 		}
@@ -282,9 +285,13 @@ func delegateDel(exec invoke.Exec, ifName string, delegateConf *types.DelegateNe
 			return logging.Errorf("Multus: error in invoke Conflist Del - %q: %v", delegateConf.ConfList.Name, err)
 		}
 	} else {
+		origpath := os.Getenv("CNI_PATH")
+		os.Setenv("CNI_PATH", origpath+":"+binDir)
 		if err = invoke.DelegateDel(context.Background(), delegateConf.Conf.Type, delegateConf.Bytes, exec); err != nil {
+			os.Setenv("CNI_PATH", origpath)
 			return logging.Errorf("Multus: error in invoke Delegate del - %q: %v", delegateConf.Conf.Type, err)
 		}
+		os.Setenv("CNI_PATH", origpath)
 	}
 
 	return err


### PR DESCRIPTION
Appends binDir to CNI_PATH so that invoke.DelegateAdd/Del can find CNI plugins in alternate paths

@s1061123 can you take a look at this? I feel like this is a ham-fisted (that is, not elegant) way of doing this by explicitly setting CNI_PATH. Feels like I am doing something wrong. Do you think there's another way to approach this?

Currently, if you set `binDir` in the configuration, like:

```
{ "name": "multus-cni-network", "type": "multus", "binDir": "/opt/multus/bin/", "logLevel": "debug", "logFile": "/var/log/multus.log", "kubeconfig": "/etc/cni/net.d/multus.d/multus.kubeconfig", "delegates": [ { "name": "cbr0", "plugins": [ { "type": "flannel", "delegate": { "hairpinMode": true, "isDefaultGateway": true } }, { "type": "portmap", "capabilities": { "portMappings": true } } ] } ] }
```

And add plugins in that directory CNI library will complain with something like:

```
2019-09-17T19:37:01Z [error] Multus: error in invoke Delegate add - "foo": failed to find plugin "foo" in path [/opt/cni/bin]
```

Where the `binDir` is not noted in the final `[]` at the end of the Delegate Add call. This error message originates here: https://github.com/containernetworking/cni/blob/master/pkg/invoke/find.go#L42

Additionally, you can see in https://github.com/containernetworking/cni/blame/master/pkg/invoke/delegate.go#L30 that the paths that get used for the `FindInPath` function are directly from the `CNI_PATH`.