### PR TITLE
[WIP] Updates daemonset for Kube 1.16, also docs and adds pre-1.16 daemonset

### DIFF
--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -39,11 +39,18 @@ Firstly, clone this GitHub repository.
 git clone https://github.com/intel/multus-cni.git && cd multus-cni
 ```
 
-We'll apply a YAML file with `kubectl` from this repo.
+If you're using Kubernetes 1.16+, we'll apply a YAML file with `kubectl` from this repo.
 
 ```
 $ cat ./images/multus-daemonset.yml | kubectl apply -f -
 ```
+
+Or, for Kubernetes versions < 1.16, use the prior version yaml:
+
+```
+$ cat ./images/multus-daemonset-pre-1.16.yml | kubectl apply -f -
+```
+
 
 ### What the Multus daemonset does
 

--- a/images/multus-daemonset-crio-pre1.16.yml
+++ b/images/multus-daemonset-crio-pre1.16.yml
@@ -141,7 +141,7 @@ spec:
         - "--cni-bin-dir=/host/usr/libexec/cni"
         - "--multus-conf-file=auto"
         - "--override-network-name=true"
-        - "--rename-conf-file=true"
+        - "--restart-crio=true"
         resources:
           requests:
             cpu: "100m"
@@ -212,6 +212,7 @@ spec:
         - "--cni-bin-dir=/host/usr/libexec/cni"
         - "--multus-conf-file=auto"
         - "--override-network-name=true"
+        - "--restart-crio=true"
         resources:
           requests:
             cpu: "100m"

--- a/images/multus-daemonset-crio-pre1.16.yml
+++ b/images/multus-daemonset-crio-pre1.16.yml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: network-attachment-definitions.k8s.cni.cncf.io
@@ -22,7 +22,7 @@ spec:
                  type: string
 ---
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: multus
 rules:
@@ -41,7 +41,7 @@ rules:
       - update
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
+apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: multus
 roleRef:
@@ -108,7 +108,7 @@ data:
       "kubeconfig": "/etc/cni/net.d/multus.d/multus.kubeconfig"
     }
 ---
-apiVersion: apps/v1
+apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   name: kube-multus-ds-amd64
@@ -116,11 +116,7 @@ metadata:
   labels:
     tier: node
     app: multus
-    name: multus
 spec:
-  selector:
-    matchLabels:
-      name: multus
   updateStrategy:
     type: RollingUpdate
   template:
@@ -128,11 +124,10 @@ spec:
       labels:
         tier: node
         app: multus
-        name: multus
     spec:
       hostNetwork: true
       nodeSelector:
-        kubernetes.io/arch: amd64
+        beta.kubernetes.io/arch: amd64
       tolerations:
       - operator: Exists
         effect: NoSchedule
@@ -143,10 +138,10 @@ spec:
         image: nfvpe/multus:latest
         command: ["/entrypoint.sh"]
         args:
-        - "--cni-version=0.3.1"
         - "--cni-bin-dir=/host/usr/libexec/cni"
         - "--multus-conf-file=auto"
-        - "--restart-crio=true"
+        - "--override-network-name=true"
+        - "--rename-conf-file=true"
         resources:
           requests:
             cpu: "100m"
@@ -184,7 +179,7 @@ spec:
             - key: cni-conf.json
               path: 70-multus.conf
 ---
-apiVersion: apps/v1
+apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   name: kube-multus-ds-ppc64le
@@ -192,11 +187,7 @@ metadata:
   labels:
     tier: node
     app: multus
-    name: multus
 spec:
-  selector:
-    matchLabels:
-      name: multus
   updateStrategy:
     type: RollingUpdate
   template:
@@ -204,11 +195,10 @@ spec:
       labels:
         tier: node
         app: multus
-        name: multus
     spec:
       hostNetwork: true
       nodeSelector:
-        kubernetes.io/arch: ppc64le
+        beta.kubernetes.io/arch: ppc64le
       tolerations:
       - operator: Exists
         effect: NoSchedule
@@ -219,10 +209,9 @@ spec:
         image: nfvpe/multus:latest-ppc64le
         command: ["/entrypoint.sh"]
         args:
-        - "--cni-version=0.3.1"
         - "--cni-bin-dir=/host/usr/libexec/cni"
         - "--multus-conf-file=auto"
-        - "--restart-crio=true"
+        - "--override-network-name=true"
         resources:
           requests:
             cpu: "100m"

--- a/images/multus-daemonset-crio.yml
+++ b/images/multus-daemonset-crio.yml
@@ -5,7 +5,6 @@ metadata:
   name: network-attachment-definitions.k8s.cni.cncf.io
 spec:
   group: k8s.cni.cncf.io
-  version: v1
   scope: Namespaced
   names:
     plural: network-attachment-definitions
@@ -13,13 +12,19 @@ spec:
     kind: NetworkAttachmentDefinition
     shortNames:
     - net-attach-def
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
           properties:
-            config:
-                 type: string
+            spec:
+              type: object
+              properties:
+                config:
+                  type: string
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/images/multus-daemonset-pre-1.16.yml
+++ b/images/multus-daemonset-pre-1.16.yml
@@ -108,7 +108,7 @@ data:
       "kubeconfig": "/etc/cni/net.d/multus.d/multus.kubeconfig"
     }
 ---
-apiVersion: apps/v1
+apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   name: kube-multus-ds-amd64
@@ -117,9 +117,6 @@ metadata:
     tier: node
     app: multus
 spec:
-  selector:
-    matchLabels:
-      name: multus
   updateStrategy:
     type: RollingUpdate
   template:
@@ -127,7 +124,6 @@ spec:
       labels:
         tier: node
         app: multus
-        name: multus
     spec:
       hostNetwork: true
       nodeSelector:
@@ -138,11 +134,10 @@ spec:
       serviceAccountName: multus
       containers:
       - name: kube-multus
-        image: nfvpe/multus:v3.3
+        image: nfvpe/multus:v3.2
         command: ["/entrypoint.sh"]
         args:
         - "--multus-conf-file=auto"
-        - "--cni-version=0.3.1"
         resources:
           requests:
             cpu: "100m"
@@ -173,7 +168,7 @@ spec:
             - key: cni-conf.json
               path: 70-multus.conf
 ---
-apiVersion: apps/v1
+apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
   name: kube-multus-ds-ppc64le
@@ -182,9 +177,6 @@ metadata:
     tier: node
     app: multus
 spec:
-  selector:
-    matchLabels:
-      name: multus
   updateStrategy:
     type: RollingUpdate
   template:
@@ -192,7 +184,6 @@ spec:
       labels:
         tier: node
         app: multus
-        name: multus
     spec:
       hostNetwork: true
       nodeSelector:
@@ -208,7 +199,6 @@ spec:
         command: ["/entrypoint.sh"]
         args:
         - "--multus-conf-file=auto"
-        - "--cni-version=0.3.1"
         resources:
           requests:
             cpu: "100m"

--- a/images/multus-daemonset.yml
+++ b/images/multus-daemonset.yml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: network-attachment-definitions.k8s.cni.cncf.io
@@ -22,7 +22,7 @@ spec:
                  type: string
 ---
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: multus
 rules:
@@ -41,7 +41,7 @@ rules:
       - update
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: multus
 roleRef:
@@ -116,6 +116,7 @@ metadata:
   labels:
     tier: node
     app: multus
+    name: multus
 spec:
   selector:
     matchLabels:
@@ -131,7 +132,7 @@ spec:
     spec:
       hostNetwork: true
       nodeSelector:
-        beta.kubernetes.io/arch: amd64
+        kubernetes.io/arch: amd64
       tolerations:
       - operator: Exists
         effect: NoSchedule
@@ -181,6 +182,7 @@ metadata:
   labels:
     tier: node
     app: multus
+    name: multus
 spec:
   selector:
     matchLabels:
@@ -196,7 +198,7 @@ spec:
     spec:
       hostNetwork: true
       nodeSelector:
-        beta.kubernetes.io/arch: ppc64le
+        kubernetes.io/arch: ppc64le
       tolerations:
       - operator: Exists
         effect: NoSchedule

--- a/images/multus-daemonset.yml
+++ b/images/multus-daemonset.yml
@@ -5,7 +5,6 @@ metadata:
   name: network-attachment-definitions.k8s.cni.cncf.io
 spec:
   group: k8s.cni.cncf.io
-  version: v1
   scope: Namespaced
   names:
     plural: network-attachment-definitions
@@ -13,13 +12,19 @@ spec:
     kind: NetworkAttachmentDefinition
     shortNames:
     - net-attach-def
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
           properties:
-            config:
-                 type: string
+            spec:
+              type: object
+              properties:
+                config:
+                  type: string
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
A few issues here...

* We will need to update the referenced image tag in the daemonset, as this plans to use the `--cni-version=` flag which isn't available in the `v3.2` tag.
* This is a WIP as I'm still experiencing some issues...

Primarily somehow the generated delegates isn't looking exactly perfect, we're hitting this error when we spin up a pod...

```
Events:
  Type     Reason                  Age        From                             Message
  ----     ------                  ----       ----                             -------
  Normal   Scheduled               <unknown>  default-scheduler                Successfully assigned default/samplepod to kube-singlehost-master
  Warning  FailedCreatePodSandBox  4s         kubelet, kube-singlehost-master  Failed create pod sandbox: rpc error: code = Unknown desc = failed to set up sandbox container "d4cd9bc70e666ba3f03f57111e759bbe84780f43a7022e42b8a153e940640a5b" network for pod "samplepod": networkPlugin cni failed to set up pod "samplepod_default" network: Multus: Err in loading K8s Delegates k8s args: Multus: Err in getting k8s network from pod: GetPodNetwork: failed getting the delegate: getKubernetesDelegate: failed to get network resource, refer Multus README.md for the usage guide: the server could not find the requested resource
  Normal   SandboxChanged          4s         kubelet, kube-singlehost-master  Pod sandbox changed, it will be killed and re-created.
[centos@kube-singlehost-master ~]$ cat /etc/cni/net.d/00-multus.conf 
{ "cniVersion": "0.3.1", "name": "multus-cni-network", "type": "multus", "kubeconfig": "/etc/cni/net.d/multus.d/multus.kubeconfig", "delegates": [ { "name": "cbr0", "cniVersion":"0.3.1", "plugins": [ { "type": "flannel", "delegate": { "hairpinMode": true, "isDefaultGateway": true } }, { "type": "portmap", "capabilities": { "portMappings": true } } ] } ] }

```

In theory when this works it can...

Fixes #379 