### PR TITLE
Add Dockerfile for building image on arm64 platform

### DIFF
--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -1,0 +1,20 @@
+# This Dockerfile is used to build the image available on DockerHub
+FROM golang:1.13.4 as build
+
+# Add everything
+ADD . /usr/src/multus-cni
+
+#ENV GOARCH "arm64"
+#ENV GOOS "linux"
+
+RUN  cd /usr/src/multus-cni && \
+     ./build
+
+# build arm64 container
+FROM centos:7
+COPY --from=build /usr/src/multus-cni /usr/src/multus-cni
+
+WORKDIR /
+ADD ./images/entrypoint.sh /
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile.arm64
+++ b/Dockerfile.arm64
@@ -4,8 +4,8 @@ FROM golang:1.13.4 as build
 # Add everything
 ADD . /usr/src/multus-cni
 
-#ENV GOARCH "arm64"
-#ENV GOOS "linux"
+ENV GOARCH "arm64"
+ENV GOOS "linux"
 
 RUN  cd /usr/src/multus-cni && \
      ./build


### PR DESCRIPTION
Add Dockerfile.arm64 for building Multus image on arm64 platform.
