### PR TITLE
[docs] Updates quickstart to use alpine image

### DIFF
--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -166,8 +166,8 @@ metadata:
 spec:
   containers:
   - name: samplepod
-    command: ["/bin/bash", "-c", "trap : TERM INT; sleep infinity & wait"]
-    image: dougbtv/centos-network
+    command: ["/bin/ash", "-c", "trap : TERM INT; sleep infinity & wait"]
+    image: alpine
 EOF
 ```
 
@@ -225,8 +225,8 @@ metadata:
 spec:
   containers:
   - name: samplepod
-    command: ["/bin/bash", "-c", "trap : TERM INT; sleep infinity & wait"]
-    image: dougbtv/centos-network
+    command: ["/bin/ash", "-c", "trap : TERM INT; sleep infinity & wait"]
+    image: alpine
 EOF
 ```
 


### PR DESCRIPTION
Was previously using `dougbtv/centos-network`, but, Alpine has the `ip` command which is all that we need for the quickstart examples (and the image size is much much smaller)