### PR TITLE
Changes wait.ExponentialBackoff to wait.PollImmediate

### DIFF
--- a/doc/how-to-use.md
+++ b/doc/how-to-use.md
@@ -619,3 +619,7 @@ When using `--multus-conf-file=auto` you may also care to specify a `binDir` in 
 Sometimes, you may wish to not have the entrypoint copy the binary file onto the host. Potentially, you have another way to copy in a specific version of Multus, for example. By default, it's always copied, but you may disable the copy with:
 
     --skip-multus-binary-copy=true
+
+If you wish to have auto configuration use the `readinessindicatorfile` in the configuration, you can use the `--readiness-indicator-file` to express which file should be used as the readiness indicator.
+
+    --readiness-indicator-file=/path/to/file

--- a/images/entrypoint.sh
+++ b/images/entrypoint.sh
@@ -28,6 +28,7 @@ MULTUS_KUBECONFIG_FILE_HOST="/etc/cni/net.d/multus.d/multus.kubeconfig"
 MULTUS_NAMESPACE_ISOLATION=false
 MULTUS_LOG_LEVEL=""
 MULTUS_LOG_FILE=""
+MULTUS_READINESS_INDICATOR_FILE=""
 OVERRIDE_NETWORK_NAME=false
 MULTUS_CLEANUP_CONFIG_ON_EXIT=false
 RESTART_CRIO=false
@@ -61,6 +62,7 @@ function usage()
     echo -e "\t--override-network-name=false (used only with --multus-conf-file=auto)"
     echo -e "\t--cleanup-config-on-exit=false (used only with --multus-conf-file=auto)"
     echo -e "\t--rename-conf-file=false (used only with --multus-conf-file=auto)"
+    echo -e "\t--readiness-indicator-file=$MULTUS_READINESS_INDICATOR_FILE (used only with --multus-conf-file=auto)"
     echo -e "\t--additional-bin-dir=$ADDITIONAL_BIN_DIR (adds binDir option to configuration, used only with --multus-conf-file=auto)"
     echo -e "\t--restart-crio=false (restarts CRIO after config file is generated)"
 }
@@ -136,6 +138,9 @@ while [ "$1" != "" ]; do
             ;;
         --skip-multus-binary-copy)
             SKIP_BINARY_COPY=$VALUE
+            ;;
+        --readiness-indicator-file)
+            MULTUS_READINESS_INDICATOR_FILE=$VALUE
             ;;
         *)
             warn "unknown parameter \"$PARAM\""
@@ -305,6 +310,12 @@ if [ "$MULTUS_CONF_FILE" == "auto" ]; then
         ADDITIONAL_BIN_DIR_STRING="\"binDir\": \"$ADDITIONAL_BIN_DIR\","
       fi
 
+
+      READINESS_INDICATOR_FILE_STRING=""
+      if [ ! -z "${MULTUS_READINESS_INDICATOR_FILE// }" ]; then
+        READINESS_INDICATOR_FILE_STRING="\"readinessindicatorfile\": \"$MULTUS_READINESS_INDICATOR_FILE\","
+      fi
+
       if [ "$OVERRIDE_NETWORK_NAME" == "true" ]; then
         MASTER_PLUGIN_NET_NAME="$(cat $MULTUS_AUTOCONF_DIR/$MASTER_PLUGIN | \
             python -c 'import json,sys;print json.load(sys.stdin)["name"]')"
@@ -324,6 +335,7 @@ if [ "$MULTUS_CONF_FILE" == "auto" ]; then
           $LOG_LEVEL_STRING
           $LOG_FILE_STRING
           $ADDITIONAL_BIN_DIR_STRING
+          $READINESS_INDICATOR_FILE_STRING
           "kubeconfig": "$MULTUS_KUBECONFIG_FILE_HOST",
           "delegates": [
             $MASTER_PLUGIN_JSON
@@ -365,8 +377,21 @@ if [ "$MULTUS_CLEANUP_CONFIG_ON_EXIT" == true ]; then
   while true; do
     # Check and see if the original master plugin configuration exists...
     if [ ! -f "$MASTER_PLUGIN_LOCATION" ]; then
-      log "Master plugin @ $MASTER_PLUGIN_LOCATION has been deleted. Performing cleanup..."
-      cleanup
+      log "Master plugin @ $MASTER_PLUGIN_LOCATION has been deleted. Allowing 45 seconds for its restoration..."
+      sleep 10
+      for i in {1..35}
+      do
+        if [ -f "$MASTER_PLUGIN_LOCATION" ]; then
+          log "Master plugin @ $MASTER_PLUGIN_LOCATION was restored. Regenerating given configuration."
+          break
+        fi
+        sleep 1
+      done
+
+      if [ ! -f "$MASTER_PLUGIN_LOCATION" ]; then
+        log "Master plugin @ $MASTER_PLUGIN_LOCATION has not been restored, beginning regeneration."
+        cleanup
+      fi
       generateMultusConf
       log "Continuing watch loop after configuration regeneration..."
     fi

--- a/multus/multus.go
+++ b/multus/multus.go
@@ -50,12 +50,8 @@ var version = "master@git"
 var commit = "unknown commit"
 var date = "unknown date"
 
-var defaultReadinessBackoff = wait.Backoff{
-	Steps:    4,
-	Duration: 250 * time.Millisecond,
-	Factor:   4.0,
-	Jitter:   0.1,
-}
+var pollDuration = 1000 * time.Millisecond
+var pollTimeout = 45 * time.Second
 
 func printVersionString() string {
 	return fmt.Sprintf("multus-cni version:%s, commit:%s, date:%s",
@@ -454,12 +450,12 @@ func cmdAdd(args *skel.CmdArgs, exec invoke.Exec, kubeClient *k8s.ClientInfo) (c
 	}
 
 	if n.ReadinessIndicatorFile != "" {
-		err := wait.ExponentialBackoff(defaultReadinessBackoff, func() (bool, error) {
+		err := wait.PollImmediate(pollDuration, pollTimeout, func() (bool, error) {
 			_, err := os.Stat(n.ReadinessIndicatorFile)
 			return err == nil, nil
 		})
 		if err != nil {
-			return nil, cmdErr(k8sArgs, "ExponentialBackoff error waiting for ReadinessIndicatorFile: %v", err)
+			return nil, cmdErr(k8sArgs, "PollImmediate error waiting for ReadinessIndicatorFile: %v", err)
 		}
 	}
 


### PR DESCRIPTION
and exposes readinessindicatorfile via entrypoint parameter.

Generally, the idea is that if we're using the ExponentialBackoff while pods are crashlooping, we're not actually saving any time. Using a poll instead allows us to pick up more quickly than Kubernetes itself does (since it's already waiting on the backoff)