### PR TITLE
Pass DeviceID to each plugin in configuration list

### DIFF
--- a/types/conf.go
+++ b/types/conf.go
@@ -339,13 +339,15 @@ func addDeviceIDInConfList(inBytes []byte, deviceID string) ([]byte, error) {
 		return nil, logging.Errorf("addDeviceIDInConfList: unable to typecast plugin list")
 	}
 
-	firstPlugin, ok := pMap[0].(map[string]interface{})
-	if !ok {
-		return nil, logging.Errorf("addDeviceIDInConfList: unable to typecast pMap")
+	for idx, plugin := range pMap {
+		currentPlugin, ok := plugin.(map[string]interface{})
+		if !ok {
+			return nil, logging.Errorf("addDeviceIDInConfList: unable to typecast plugin #%d", idx)
+		}
+		// Inject deviceID
+		currentPlugin["deviceID"] = deviceID
+		currentPlugin["pciBusID"] = deviceID
 	}
-	// Inject deviceID
-	firstPlugin["deviceID"] = deviceID
-	firstPlugin["pciBusID"] = deviceID
 
 	configBytes, err := json.Marshal(rawConfig)
 	if err != nil {

--- a/types/conf_test.go
+++ b/types/conf_test.go
@@ -314,6 +314,37 @@ var _ = Describe("config operations", func() {
 		Expect(sriovConfList.Plugins[0].DeviceID).To(Equal("0000:00:00.1"))
 	})
 
+	It("assigns deviceID in delegated conf list multiple plugins", func() {
+		conf := `{
+    "name": "second-network",
+    "plugins": [
+      {
+        "type": "sriov"
+      },
+      {
+        "type": "other-cni"
+      }
+    ]
+}`
+		type sriovNetConf struct {
+			Name     string `json:"name"`
+			Type     string `json:"type"`
+			DeviceID string `json:"deviceID"`
+		}
+		type sriovNetConfList struct {
+			Plugins []*sriovNetConf `json:"plugins"`
+		}
+		sriovConfList := &sriovNetConfList{}
+		delegateNetConf, err := LoadDelegateNetConf([]byte(conf), nil, "0000:00:00.1")
+		Expect(err).NotTo(HaveOccurred())
+
+		err = json.Unmarshal(delegateNetConf.Bytes, &sriovConfList)
+		Expect(err).NotTo(HaveOccurred())
+		for _, plugin := range sriovConfList.Plugins {
+			Expect(plugin.DeviceID).To(Equal("0000:00:00.1"))
+		}
+	})
+
 	It("assigns pciBusID in delegated conf", func() {
 		conf := `{
     "name": "second-network",
@@ -357,6 +388,37 @@ var _ = Describe("config operations", func() {
 		err = json.Unmarshal(delegateNetConf.Bytes, &hostDeviceConfList)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(hostDeviceConfList.Plugins[0].PCIBusID).To(Equal("0000:00:00.3"))
+	})
+
+	It("assigns pciBusID in delegated conf list multiple plugins", func() {
+		conf := `{
+    "name": "second-network",
+    "plugins": [
+      {
+        "type": "host-device"
+      },
+      {
+        "type": "other-cni"
+      }
+    ]
+}`
+		type hostDeviceNetConf struct {
+			Name     string `json:"name"`
+			Type     string `json:"type"`
+			PCIBusID string `json:"pciBusID"`
+		}
+		type hostDeviceNetConfList struct {
+			Plugins []*hostDeviceNetConf `json:"plugins"`
+		}
+		hostDeviceConfList := &hostDeviceNetConfList{}
+		delegateNetConf, err := LoadDelegateNetConf([]byte(conf), nil, "0000:00:00.3")
+		Expect(err).NotTo(HaveOccurred())
+
+		err = json.Unmarshal(delegateNetConf.Bytes, &hostDeviceConfList)
+		Expect(err).NotTo(HaveOccurred())
+		for _, plugin := range hostDeviceConfList.Plugins {
+			Expect(plugin.PCIBusID).To(Equal("0000:00:00.3"))
+		}
 	})
 
 	It("add cni-args in config", func() {


### PR DESCRIPTION
Until today, it was hardcoded that DeviceID will only be
injected for the first CNI in the chain.

This commit modifies multus to pass DeviceID to each network
configuration element in a network configuration list.
This will  allow multiple CNI's to act on DeviceID when CNI
plugins are being chained for a specific network.

The change is required to allow CNI's to ensure network
isolation (introduced in kernel >= 5.2.0 see [1]) for RDMA devices
when exist.

e.g for SR-IOV network:
sriov-cni moves network device associated with the provided DeviceID
to to the container's network namespace.
An "RDMA cni" would do the same for the corresponding RDMA device when
RDMA traffic is desired on the network.

[1] https://patchwork.kernel.org/cover/10810451/