### PR TITLE
Fix pre 1.16 api version for CRDs

### DIFF
--- a/images/multus-daemonset-crio-pre1.16.yml
+++ b/images/multus-daemonset-crio-pre1.16.yml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: network-attachment-definitions.k8s.cni.cncf.io

--- a/images/multus-daemonset-pre-1.16.yml
+++ b/images/multus-daemonset-pre-1.16.yml
@@ -1,5 +1,5 @@
 ---
-apiVersion: apiextensions.k8s.io/v1
+apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: network-attachment-definitions.k8s.cni.cncf.io


### PR DESCRIPTION
This was broken during the improvement for descriptions.