### PR TITLE
Check Pod parameter against nil before calling Eventf

### DIFF
--- a/multus/multus.go
+++ b/multus/multus.go
@@ -355,11 +355,13 @@ func delegateAdd(exec invoke.Exec, kubeClient *k8s.ClientInfo, pod *v1.Pod, ifNa
 		ips = append(ips, ip.Address.String())
 	}
 
-	// send kubernetes events
-	if delegate.Name != "" {
-		kubeClient.Eventf(pod, v1.EventTypeNormal, "AddedInterface", "Add %s %v from %s", rt.IfName, ips, delegate.Name)
-	} else {
-		kubeClient.Eventf(pod, v1.EventTypeNormal, "AddedInterface", "Add %s %v", rt.IfName, ips)
+	if pod != nil {
+		// send kubernetes events
+		if delegate.Name != "" {
+			kubeClient.Eventf(pod, v1.EventTypeNormal, "AddedInterface", "Add %s %v from %s", rt.IfName, ips, delegate.Name)
+		} else {
+			kubeClient.Eventf(pod, v1.EventTypeNormal, "AddedInterface", "Add %s %v", rt.IfName, ips)
+		}
 	}
 
 	return result, nil


### PR DESCRIPTION
Fixes #481 

Here is the tip of stack trace:
```
Apr 16 19:03:00.175064 ci-op-nqdgf-m-0.c.openshift-gce-devel-ci.internal crio[1370]: 2020-04-16T19:03:00Z [verbose] Add: openshift-console:downloads-dc9498995-p4vgn:unknownUID:(openshift-sdn):eth0 {"cniVersion":"0.3.1","interfaces":[{"name":"eth0","sandbox":"/proc/20411/ns/net"}],"ips":[{"version":"4","interface":0,"address":"10.129.0.18/23"}],"routes":[{"dst":"0.0.0.0/0","gw":"10.129.0.1"},{"dst":"224.0.0.0/4"},{"dst":"10.128.0.0/14"}],"dns":{}}
Apr 16 19:03:00.177321 ci-op-nqdgf-m-0.c.openshift-gce-devel-ci.internal crio[1370]: panic: runtime error: invalid memory address or nil pointer dereference
Apr 16 19:03:00.177321 ci-op-nqdgf-m-0.c.openshift-gce-devel-ci.internal crio[1370]: [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xa62075]
Apr 16 19:03:00.177321 ci-op-nqdgf-m-0.c.openshift-gce-devel-ci.internal crio[1370]: goroutine 1 [running]:
Apr 16 19:03:00.177545 ci-op-nqdgf-m-0.c.openshift-gce-devel-ci.internal crio[1370]: panic(0x11ed400, 0x1e95e80)
Apr 16 19:03:00.177545 ci-op-nqdgf-m-0.c.openshift-gce-devel-ci.internal crio[1370]:         /usr/lib/golang/src/runtime/panic.go:722 +0x2c2 fp=0xc000243300 sp=0xc000243270 pc=0x433e32
Apr 16 19:03:00.177545 ci-op-nqdgf-m-0.c.openshift-gce-devel-ci.internal crio[1370]: runtime.panicmem(...)
Apr 16 19:03:00.177545 ci-op-nqdgf-m-0.c.openshift-gce-devel-ci.internal crio[1370]:         /usr/lib/golang/src/runtime/panic.go:199
Apr 16 19:03:00.177545 ci-op-nqdgf-m-0.c.openshift-gce-devel-ci.internal crio[1370]: runtime.sigpanic()
Apr 16 19:03:00.177545 ci-op-nqdgf-m-0.c.openshift-gce-devel-ci.internal crio[1370]:         /usr/lib/golang/src/runtime/signal_unix.go:394 +0x3ec fp=0xc000243330 sp=0xc000243300 pc=0x448b5c
Apr 16 19:03:00.177545 ci-op-nqdgf-m-0.c.openshift-gce-devel-ci.internal crio[1370]: github.com/intel/multus-cni/vendor/k8s.io/api/core/v1.(*Pod).GetObjectKind(0x0, 0xc000243378, 0x4e4ec1)
Apr 16 19:03:00.177545 ci-op-nqdgf-m-0.c.openshift-gce-devel-ci.internal crio[1370]:         <autogenerated>:1 +0x5 fp=0xc000243338 sp=0xc000243330 pc=0xa62075
Apr 16 19:03:00.177545 ci-op-nqdgf-m-0.c.openshift-gce-devel-ci.internal crio[1370]: github.com/intel/multus-cni/vendor/k8s.io/client-go/tools/reference.GetReference(0xc00013bce0, 0x1512ba0, 0x0, 0x4edb6b, 0xc0003e84e0, 0x115ef60)
```
It seems Pod parameter was nil.

This PR adds check for Pod parameter.