### PR TITLE
Updates Dockerfile to golang 1.13 (specifying version)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM centos:centos7 as build
 # Add everything
 ADD . /usr/src/multus-cni
 
-ENV INSTALL_PKGS "git golang"
+ENV INSTALL_PKGS "git golang-1.13.10-0.el7.x86_64"
 RUN rpm --import https://mirror.go-repo.io/centos/RPM-GPG-KEY-GO-REPO && \
     curl -s https://mirror.go-repo.io/centos/go-repo.repo | tee /etc/yum.repos.d/go-repo.repo && \
     yum install -y $INSTALL_PKGS && \


### PR DESCRIPTION
I happened to notice that go-repo.io has 1.13 packages, took a look through `yum search golang --showduplicates

```
$ yum search golang --show-duplicates | grep "golang-1.13"
golang-1.13-0.el7.x86_64 : The Go Programming Language
golang-1.13.1-0.el7.x86_64 : The Go Programming Language
golang-1.13.2-0.el7.x86_64 : The Go Programming Language
golang-1.13.3-0.el7.x86_64 : The Go Programming Language
golang-1.13.4-0.el7.x86_64 : The Go Programming Language
golang-1.13.5-0.el7.x86_64 : The Go Programming Language
golang-1.13.6-0.el7.x86_64 : The Go Programming Language
golang-1.13.7-0.el7.x86_64 : The Go Programming Language
golang-1.13.8-0.el7.x86_64 : The Go Programming Language
golang-1.13.9-0.el7.x86_64 : The Go Programming Language
golang-1.13.10-0.el7.x86_64 : The Go Programming Language
golang-1.13.10-0.el7.x86_64 : The Go Programming Language
```

Happy to take other ideas, but, this may be one direction