### PR TITLE
Support Infiniband guid CNI runtime config

### DIFF
--- a/k8sclient/k8sclient.go
+++ b/k8sclient/k8sclient.go
@@ -210,6 +210,12 @@ func parsePodNetworkAnnotation(podNetworks, defaultNamespace string) ([]*types.N
 				return nil, logging.Errorf("parsePodNetworkAnnotation: failed to mac: %v", err)
 			}
 		}
+		if n.InfinibandGUIDRequest != "" {
+			// validate GUID address
+			if _, err := net.ParseMAC(n.InfinibandGUIDRequest); err != nil {
+				return nil, logging.Errorf("parsePodNetworkAnnotation: failed to validate infiniband GUID: %v", err)
+			}
+		}
 		if n.IPRequest != nil {
 			for _, ip := range n.IPRequest {
 				// validate IP address

--- a/types/conf.go
+++ b/types/conf.go
@@ -117,6 +117,9 @@ func LoadDelegateNetConf(bytes []byte, net *NetworkSelectionElement, deviceID st
 		if net.GatewayRequest != nil {
 			delegateConf.GatewayRequest = append(delegateConf.GatewayRequest, net.GatewayRequest...)
 		}
+		if net.InfinibandGUIDRequest != "" {
+			delegateConf.InfinibandGUIDRequest = net.InfinibandGUIDRequest
+		}
 	}
 
 	delegateConf.Bytes = bytes
@@ -145,6 +148,9 @@ func MergeCNIRuntimeConfig(runtimeConfig *RuntimeConfig, delegate *DelegateNetCo
 		}
 		if delegate.MacRequest != "" {
 			runtimeConfig.Mac = delegate.MacRequest
+		}
+		if delegate.InfinibandGUIDRequest != "" {
+			runtimeConfig.InfinibandGUID = delegate.InfinibandGUIDRequest
 		}
 	}
 
@@ -184,6 +190,9 @@ func CreateCNIRuntimeConf(args *skel.CmdArgs, k8sArgs *K8sArgs, ifName string, r
 		}
 		if len(rc.Mac) != 0 {
 			capabilityArgs["mac"] = rc.Mac
+		}
+		if len(rc.InfinibandGUID) != 0 {
+			capabilityArgs["infinibandGUID"] = rc.InfinibandGUID
 		}
 		rt.CapabilityArgs = capabilityArgs
 	}

--- a/types/conf_test.go
+++ b/types/conf_test.go
@@ -659,18 +659,20 @@ var _ = Describe("config operations", func() {
 		}
 
 		networkSelection := &NetworkSelectionElement{
-			Name:                "testname",
-			InterfaceRequest:    "testIF1",
-			MacRequest:          "c2:11:22:33:44:66",
-			IPRequest:           []string{"10.0.0.1/24"},
-			BandwidthRequest:    bandwidthEntry1,
-			PortMappingsRequest: []*PortMapEntry{portMapEntry1},
+			Name:                  "testname",
+			InterfaceRequest:      "testIF1",
+			MacRequest:            "c2:11:22:33:44:66",
+			InfinibandGUIDRequest: "24:8a:07:03:00:8d:ae:2e",
+			IPRequest:             []string{"10.0.0.1/24"},
+			BandwidthRequest:      bandwidthEntry1,
+			PortMappingsRequest:   []*PortMapEntry{portMapEntry1},
 		}
 
 		delegateConf, err := LoadDelegateNetConf([]byte(cniConfig), networkSelection, "")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(delegateConf.IfnameRequest).To(Equal(networkSelection.InterfaceRequest))
 		Expect(delegateConf.MacRequest).To(Equal(networkSelection.MacRequest))
+		Expect(delegateConf.InfinibandGUIDRequest).To(Equal(networkSelection.InfinibandGUIDRequest))
 		Expect(delegateConf.IPRequest).To(Equal(networkSelection.IPRequest))
 		Expect(delegateConf.BandwidthRequest).To(Equal(networkSelection.BandwidthRequest))
 		Expect(delegateConf.PortMappingsRequest).To(Equal(networkSelection.PortMappingsRequest))
@@ -704,12 +706,13 @@ var _ = Describe("config operations", func() {
 		}
 
 		networkSelection := &NetworkSelectionElement{
-			Name:                "testname",
-			InterfaceRequest:    "testIF1",
-			MacRequest:          "c2:11:22:33:44:66",
-			IPRequest:           []string{"10.0.0.1/24"},
-			BandwidthRequest:    bandwidthEntry1,
-			PortMappingsRequest: []*PortMapEntry{portMapEntry1},
+			Name:                  "testname",
+			InterfaceRequest:      "testIF1",
+			MacRequest:            "c2:11:22:33:44:66",
+			InfinibandGUIDRequest: "24:8a:07:03:00:8d:ae:2e",
+			IPRequest:             []string{"10.0.0.1/24"},
+			BandwidthRequest:      bandwidthEntry1,
+			PortMappingsRequest:   []*PortMapEntry{portMapEntry1},
 		}
 		delegate, err := LoadDelegateNetConf([]byte(conf), networkSelection, "")
 		delegate.MasterPlugin = true
@@ -717,6 +720,7 @@ var _ = Describe("config operations", func() {
 		runtimeConf := MergeCNIRuntimeConfig(&RuntimeConfig{}, delegate)
 		Expect(runtimeConf.PortMaps).To(BeNil())
 		Expect(runtimeConf.Bandwidth).To(BeNil())
+		Expect(runtimeConf.InfinibandGUID).To(Equal(""))
 	})
 
 	It("test MergeCNIRuntimeConfig with delegate plugin", func() {
@@ -739,12 +743,13 @@ var _ = Describe("config operations", func() {
 		}
 
 		networkSelection := &NetworkSelectionElement{
-			Name:                "testname",
-			InterfaceRequest:    "testIF1",
-			MacRequest:          "c2:11:22:33:44:66",
-			IPRequest:           []string{"10.0.0.1/24"},
-			BandwidthRequest:    bandwidthEntry1,
-			PortMappingsRequest: []*PortMapEntry{portMapEntry1},
+			Name:                  "testname",
+			InterfaceRequest:      "testIF1",
+			MacRequest:            "c2:11:22:33:44:66",
+			InfinibandGUIDRequest: "24:8a:07:03:00:8d:ae:2e",
+			IPRequest:             []string{"10.0.0.1/24"},
+			BandwidthRequest:      bandwidthEntry1,
+			PortMappingsRequest:   []*PortMapEntry{portMapEntry1},
 		}
 		delegate, err := LoadDelegateNetConf([]byte(conf), networkSelection, "")
 		Expect(err).NotTo(HaveOccurred())
@@ -755,5 +760,6 @@ var _ = Describe("config operations", func() {
 		Expect(runtimeConf.Bandwidth).To(Equal(bandwidthEntry1))
 		Expect(len(runtimeConf.IPs)).To(BeEquivalentTo(1))
 		Expect(runtimeConf.Mac).To(Equal("c2:11:22:33:44:66"))
+		Expect(runtimeConf.InfinibandGUID).To(Equal("24:8a:07:03:00:8d:ae:2e"))
 	})
 })

--- a/types/types.go
+++ b/types/types.go
@@ -57,10 +57,11 @@ type NetConf struct {
 
 // RuntimeConfig specifies CNI RuntimeConfig
 type RuntimeConfig struct {
-	PortMaps  []*PortMapEntry `json:"portMappings,omitempty"`
-	Bandwidth *BandwidthEntry `json:"bandwidth,omitempty"`
-	IPs       []string        `json:"ips,omitempty"`
-	Mac       string          `json:"mac,omitempty"`
+	PortMaps       []*PortMapEntry `json:"portMappings,omitempty"`
+	Bandwidth      *BandwidthEntry `json:"bandwidth,omitempty"`
+	IPs            []string        `json:"ips,omitempty"`
+	Mac            string          `json:"mac,omitempty"`
+	InfinibandGUID string          `json:"infinibandGUID,omitempty"`
 }
 
 // PortMapEntry for CNI PortMapEntry
@@ -92,16 +93,17 @@ type NetworkStatus struct {
 
 // DelegateNetConf for net-attach-def for pod
 type DelegateNetConf struct {
-	Conf                types.NetConf
-	ConfList            types.NetConfList
-	Name                string
-	IfnameRequest       string          `json:"ifnameRequest,omitempty"`
-	MacRequest          string          `json:"macRequest,omitempty"`
-	IPRequest           []string        `json:"ipRequest,omitempty"`
-	PortMappingsRequest []*PortMapEntry `json:"-"`
-	BandwidthRequest    *BandwidthEntry `json:"-"`
-	GatewayRequest      []net.IP        `json:"default-route,omitempty"`
-	IsFilterGateway     bool
+	Conf                  types.NetConf
+	ConfList              types.NetConfList
+	Name                  string
+	IfnameRequest         string          `json:"ifnameRequest,omitempty"`
+	MacRequest            string          `json:"macRequest,omitempty"`
+	InfinibandGUIDRequest string          `json:"infinibandGUIDRequest,omitempty"`
+	IPRequest             []string        `json:"ipRequest,omitempty"`
+	PortMappingsRequest   []*PortMapEntry `json:"-"`
+	BandwidthRequest      *BandwidthEntry `json:"-"`
+	GatewayRequest        []net.IP        `json:"default-route,omitempty"`
+	IsFilterGateway       bool
 	// MasterPlugin is only used internal housekeeping
 	MasterPlugin bool `json:"-"`
 	// Conflist plugin is only used internal housekeeping
@@ -126,6 +128,9 @@ type NetworkSelectionElement struct {
 	// MacRequest contains an optional requested MAC address for this
 	// network attachment
 	MacRequest string `json:"mac,omitempty"`
+	// InfinibandGUID request contains an optional requested Infiniband GUID address
+	// for this network attachment
+	InfinibandGUIDRequest string `json:"infiniband-guid,omitempty"`
 	// InterfaceRequest contains an optional requested name for the
 	// network interface this attachment will create in the container
 	InterfaceRequest string `json:"interface,omitempty"`


### PR DESCRIPTION
This PR add support for a new CNI runtime config attribute

`InfinibandGUID` CNI runtime config which was introduced in [PR 742](https://github.com/containernetworking/cni/pull/742)

the corresponding network-attachment attribute is proposed to be defined as `infiniband-guid`
and discussed in [multi-net-spec PR 4](https://github.com/k8snetworkplumbingwg/multi-net-spec/issues/4)

A CNI implementation consuming this runtime config attribute (and can be used as reference) is proposed in [ib-sriov-cni PR 28](https://github.com/Mellanox/ib-sriov-cni/pull/28)

