### PR TITLE
build: Enable -mod build flag to be toggled via environment variable

### DIFF
--- a/build
+++ b/build
@@ -44,7 +44,11 @@ if [ "$GO111MODULE" == "off" ]; then
 else
 	# build with go modules
 	export GO111MODULE=on
+	BUILD_ARGS=(-o ${DEST_DIR}/multus -tags no_openssl)
+	if [ -n "$MODMODE" ]; then
+		BUILD_ARGS+=(-mod "$MODMODE")
+	fi
 
 	echo "Building plugins"
-	go build -o ${DEST_DIR}/multus -tags no_openssl -ldflags "${LDFLAGS}" "$@" ./multus
+	go build ${BUILD_ARGS[*]} -ldflags "${LDFLAGS}" "$@" ./multus
 fi


### PR DESCRIPTION
This change will enable builds to be performed with the option of
passing the -mod flag to 'go build'. This can be done by optionally
setting the MODMODE environment variable prior to building.

For example, toggling the -mod setting for the build can be
accomplished as follows:

```
$ MODMODE=vendor ./build
```

Signed-off-by: Ryan Tidwell <rtidwell@suse.com>