### PR TITLE
Allow to override build date with SOURCE_DATE_EPOCH

### DIFF
--- a/build
+++ b/build
@@ -19,7 +19,7 @@ if [ -z "$VERSION" ]; then
 	fi
 	set -e
 fi
-DATE=$(date --iso-8601=seconds)
+DATE=$(date -u -d "@${SOURCE_DATE_EPOCH:-$(date +%s)}" --iso-8601=seconds)
 COMMIT=${COMMIT:-$(git rev-parse --verify HEAD)}
 LDFLAGS="-X main.version=${VERSION:-master} -X main.commit=${COMMIT} -X main.date=${DATE}"
 export CGO_ENABLED=0


### PR DESCRIPTION
Allow to override build date with `SOURCE_DATE_EPOCH`
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.

This `date` call only works with GNU date (probably not a problem since kubernes is pretty Linux-specific).

Also use UTC to be independent of timezone.