### PR TITLE
Specify image repo URL explicitly

### DIFF
--- a/images/multus-daemonset-crio.yml
+++ b/images/multus-daemonset-crio.yml
@@ -172,7 +172,7 @@ spec:
       containers:
       - name: kube-multus
         # crio support requires multus:latest for now. support 3.3 or later.
-        image: nfvpe/multus:v3.6
+        image: docker.io/nfvpe/multus:stable
         command: ["/entrypoint.sh"]
         args:
         - "--cni-version=0.3.1"
@@ -248,7 +248,7 @@ spec:
       containers:
       - name: kube-multus
         # crio support requires multus:latest for now. support 3.3 or later.
-        image: nfvpe/multus:latest-ppc64le
+        image: docker.io/nfvpe/multus:stable-ppc64le
         command: ["/entrypoint.sh"]
         args:
         - "--cni-version=0.3.1"

--- a/images/multus-daemonset-gke-1.16.yml
+++ b/images/multus-daemonset-gke-1.16.yml
@@ -144,7 +144,7 @@ spec:
       serviceAccountName: multus
       containers:
         - name: kube-multus
-          image: nfvpe/multus:v3.6
+          image: docker.io/nfvpe/multus:stable
           command: ["/entrypoint.sh"]
           args:
             - "--multus-conf-file=auto"
@@ -212,7 +212,7 @@ spec:
       containers:
         - name: kube-multus
           # ppc64le support requires multus:latest for now. support 3.3 or later.
-          image: nfvpe/multus:latest-ppc64le
+          image: docker.io/nfvpe/multus:stable-ppc64le
           command: ["/entrypoint.sh"]
           args:
             - "--multus-conf-file=auto"

--- a/images/multus-daemonset.yml
+++ b/images/multus-daemonset.yml
@@ -171,7 +171,7 @@ spec:
       serviceAccountName: multus
       containers:
       - name: kube-multus
-        image: nfvpe/multus:v3.6
+        image: docker.io/nfvpe/multus:stable
         command: ["/entrypoint.sh"]
         args:
         - "--multus-conf-file=auto"
@@ -238,7 +238,7 @@ spec:
       containers:
       - name: kube-multus
         # ppc64le support requires multus:latest for now. support 3.3 or later.
-        image: nfvpe/multus:latest-ppc64le
+        image: docker.io/nfvpe/multus:stable-ppc64le
         command: ["/entrypoint.sh"]
         args:
         - "--multus-conf-file=auto"


### PR DESCRIPTION
This fix supplies domain for container image repo because
in some runtime configuration, 'docker.io' is not specified as
default container repository url.