### PR TITLE
Allows specifying "global namespaces" when using namespace isolation

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -119,6 +119,8 @@ The functionality provided by the `namespaceIsolation` configuration option enab
 
 **NOTE**: The default namespace is special in this scenario. Even with namespace isolation enabled, any pod, in any namespace is allowed to refer to `NetworkAttachmentDefinitions` in the default namespace. This allows you to create commonly used unprivileged `NetworkAttachmentDefinitions` without having to put them in all namespaces. For example, if you had a `NetworkAttachmentDefinition` named `foo` the default namespace, you may reference it in an annotation with: `default/foo`.
 
+**NOTE**: You can also add additional namespaces which can be referred to globally using the `global-namespaces` option (see next section).
+
 For example, if a pod is created in the namespace called `development`, Multus will not allow networks to be attached when defined by custom resources created in a different namespace, say in the `default` network.
 
 Consider the situation where you have a system that has users of different privilege levels -- as an example, a platform which has two administrators: a Senior Administrator and a Junior Administrator. The Senior Administrator may have access to all namespaces, and some network configurations as used by Multus are considered to be privileged in that they allow access to some protected resources available on the network. However, the Junior Administrator has access to only a subset of namespaces, and therefore it should be assumed that the Junior Administrator cannot create pods in their limited subset of namespaces. The `namespaceIsolation` feature provides for this isolation, allowing pods created in given namespaces to only access custom resources in the same namespace as the pod.
@@ -215,7 +217,7 @@ pod/samplepod created
 You'll note that pod fails to spawn successfully. If you check the Multus logs, you'll see an entry such as:
 
 ```
-2018-12-18T21:41:32Z [error] GetPodNetwork: namespace isolation violation: podnamespace: development / target namespace: privileged
+2018-12-18T21:41:32Z [error] GetNetworkDelegates: namespace isolation enabled, annotation violates permission, pod is in namespace development but refers to target namespace privileged
 ```
 
 This error expresses that the pod resides in the namespace named `development` but refers to a `NetworkAttachmentDefinition` outside of that namespace, in this case, the namespace named `privileged`.
@@ -252,6 +254,16 @@ pod/samplepod created
 NAME        READY   STATUS    RESTARTS   AGE
 samplepod   1/1     Running   0          31s
 ```
+
+### Allow specific namespaces to be used across namespaces when using namespace isolation
+
+The `globalNamespaces` configuration option is only used when `namespaceIsolation` is set to true. `globalNamespaces` specifies a comma-delimited list of namespaces which can be referred to from outside of any given namespace in which a pod resides.
+
+```
+  "globalNamespaces": "default,namespace-a,namespace-b",
+```
+
+Note that when using `globalNamespaces` the `default` namespace must be specified in the list if you wish to use that namespace, when `globalNamespaces` is not set, the `default` namespace is implied to be used across namespaces.
 
 ### Specify default cluster network in Pod annotations
 

--- a/doc/how-to-use.md
+++ b/doc/how-to-use.md
@@ -567,7 +567,11 @@ This the directory in which the Multus binary will be installed.
 
     --namespace-isolation=false
 
-Setting this option to true enables the Namespace isolation feature, which insists that custom resources must be created in the same namespace as the pods, otherwise it will refuse to attach those definitions as additional interfaces.
+Setting this option to true enables the Namespace isolation feature, which insists that custom resources must be created in the same namespace as the pods, otherwise it will refuse to attach those definitions as additional interfaces. See (the configuration guide for more information)[configuration.md].
+
+    --global-namespaces=default,foo,bar
+
+The `--global-namespaces` works only when `--namespace-isolation=true`. This takes a comma-separated list of namespaces which can be referred to globally when namespace isolation is enabled. See (the configuration guide for more information)[configuration.md].
 
     --multus-bin-file=/usr/src/multus-cni/bin/multus
 

--- a/images/entrypoint.sh
+++ b/images/entrypoint.sh
@@ -12,6 +12,7 @@ MULTUS_AUTOCONF_DIR="/host/etc/cni/net.d"
 MULTUS_BIN_FILE="/usr/src/multus-cni/bin/multus"
 MULTUS_KUBECONFIG_FILE_HOST="/etc/cni/net.d/multus.d/multus.kubeconfig"
 MULTUS_NAMESPACE_ISOLATION=false
+MULTUS_GLOBAL_NAMESPACES=""
 MULTUS_LOG_LEVEL=""
 MULTUS_LOG_FILE=""
 MULTUS_READINESS_INDICATOR_FILE=""
@@ -42,6 +43,7 @@ function usage()
     echo -e "\t--skip-multus-binary-copy=$SKIP_BINARY_COPY"
     echo -e "\t--multus-kubeconfig-file-host=$MULTUS_KUBECONFIG_FILE_HOST"
     echo -e "\t--namespace-isolation=$MULTUS_NAMESPACE_ISOLATION"
+    echo -e "\t--global-namespaces=$MULTUS_GLOBAL_NAMESPACES (used only with --namespace-isolation=true)"
     echo -e "\t--multus-autoconfig-dir=$MULTUS_AUTOCONF_DIR (used only with --multus-conf-file=auto)"
     echo -e "\t--multus-log-level=$MULTUS_LOG_LEVEL (empty by default, used only with --multus-conf-file=auto)"
     echo -e "\t--multus-log-file=$MULTUS_LOG_FILE (empty by default, used only with --multus-conf-file=auto)"
@@ -97,6 +99,9 @@ while [ "$1" != "" ]; do
             ;;
         --namespace-isolation)
             MULTUS_NAMESPACE_ISOLATION=$VALUE
+            ;;
+        --global-namespaces)
+            MULTUS_GLOBAL_NAMESPACES=$VALUE
             ;;
         --multus-log-level)
             MULTUS_LOG_LEVEL=$VALUE
@@ -255,6 +260,11 @@ if [ "$MULTUS_CONF_FILE" == "auto" ]; then
         ISOLATION_STRING="\"namespaceIsolation\": true,"
       fi
 
+      GLOBAL_NAMESPACES_STRING=""
+      if [ ! -z "${MULTUS_GLOBAL_NAMESPACES// }" ]; then
+        GLOBAL_NAMESPACES_STRING="\"globalNamespaces\": \"$MULTUS_GLOBAL_NAMESPACES\","
+      fi
+
       LOG_LEVEL_STRING=""
       if [ ! -z "${MULTUS_LOG_LEVEL// }" ]; then
         case "$MULTUS_LOG_LEVEL" in
@@ -330,6 +340,7 @@ EOF
           "type": "multus",
           $NESTED_CAPABILITIES_STRING
           $ISOLATION_STRING
+          $GLOBAL_NAMESPACES_STRING
           $LOG_LEVEL_STRING
           $LOG_FILE_STRING
           $ADDITIONAL_BIN_DIR_STRING

--- a/types/conf.go
+++ b/types/conf.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"strings"
 
 	"github.com/containernetworking/cni/libcni"
 	"github.com/containernetworking/cni/pkg/skel"
@@ -33,6 +34,7 @@ const (
 	defaultBinDir                 = "/opt/cni/bin"
 	defaultReadinessIndicatorFile = ""
 	defaultMultusNamespace        = "kube-system"
+	defaultNonIsolatedNamespace   = "default"
 )
 
 // LoadDelegateNetConfList reads DelegateNetConf from bytes
@@ -279,6 +281,19 @@ func LoadNetConf(bytes []byte) (*NetConf, error) {
 
 	if netconf.MultusNamespace == "" {
 		netconf.MultusNamespace = defaultMultusNamespace
+	}
+
+	// setup namespace isolation
+	if netconf.RawNonIsolatedNamespaces == "" {
+		netconf.NonIsolatedNamespaces = []string{defaultNonIsolatedNamespace}
+	} else {
+		// Parse the comma separated list
+		nonisolated := strings.Split(netconf.RawNonIsolatedNamespaces, ",")
+		// Cleanup the whitespace
+		for i, nonv := range nonisolated {
+			nonisolated[i] = strings.TrimSpace(nonv)
+		}
+		netconf.NonIsolatedNamespaces = nonisolated
 	}
 
 	// get RawDelegates and put delegates field

--- a/types/conf_test.go
+++ b/types/conf_test.go
@@ -135,6 +135,47 @@ var _ = Describe("config operations", func() {
 		Expect(netConf.LogFile).To(Equal("/var/log/multus.log"))
 	})
 
+	It("properly sets namespace isolation using the default namespace", func() {
+		conf := `{
+	    "name": "node-cni-network",
+	    "type": "multus",
+	    "logLevel": "debug",
+	    "logFile": "/var/log/multus.log",
+	    "kubeconfig": "/etc/kubernetes/node-kubeconfig.yaml",
+	    "namespaceIsolation": true,
+	    "delegates": [{
+	        "type": "weave-net"
+	    }]
+	}`
+		netConf, err := LoadNetConf([]byte(conf))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(netConf.NamespaceIsolation).To(Equal(true))
+		Expect(len(netConf.NonIsolatedNamespaces)).To(Equal(1))
+		Expect(netConf.NonIsolatedNamespaces[0]).To(Equal("default"))
+	})
+
+	It("properly sets namespace isolation using custom namespaces", func() {
+		conf := `{
+	    "name": "node-cni-network",
+	    "type": "multus",
+	    "logLevel": "debug",
+	    "logFile": "/var/log/multus.log",
+	    "kubeconfig": "/etc/kubernetes/node-kubeconfig.yaml",
+	    "namespaceIsolation": true,
+	    "globalNamespaces": " foo,bar ,default",
+	    "delegates": [{
+	        "type": "weave-net"
+	    }]
+	}`
+		netConf, err := LoadNetConf([]byte(conf))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(netConf.NamespaceIsolation).To(Equal(true))
+		Expect(len(netConf.NonIsolatedNamespaces)).To(Equal(3))
+		Expect(netConf.NonIsolatedNamespaces[0]).To(Equal("foo"))
+		Expect(netConf.NonIsolatedNamespaces[1]).To(Equal("bar"))
+		Expect(netConf.NonIsolatedNamespaces[2]).To(Equal("default"))
+	})
+
 	It("prevResult with no errors", func() {
 		conf := `{
 	    "name": "node-cni-network",

--- a/types/types.go
+++ b/types/types.go
@@ -48,7 +48,10 @@ type NetConf struct {
 	// Default network readiness options
 	ReadinessIndicatorFile string `json:"readinessindicatorfile"`
 	// Option to isolate the usage of CR's to the namespace in which a pod resides.
-	NamespaceIsolation bool `json:"namespaceIsolation"`
+	NamespaceIsolation       bool     `json:"namespaceIsolation"`
+	RawNonIsolatedNamespaces string   `json:"globalNamespaces"`
+	NonIsolatedNamespaces    []string `json:"-"`
+
 	// Option to set system namespaces (to avoid to add defaultNetworks)
 	SystemNamespaces []string `json:"systemNamespaces"`
 	// Option to set the namespace that multus-cni uses (clusterNetwork/defaultNetworks)


### PR DESCRIPTION
When using `namespaceIsolation` -- we have only allowed for referring to the `default` namespace from any given namespace. This enhancement adds a configuration option `globalNamespaces` which allows one to specify any additional namespaces which they would like to refer to "globally" -- that is, from any given namespace (as opposed to "locally" -- from the same namespace in which a pod resides, which is the core functionality of `namespaceIsolation`).

The `globalNamespaces` parameter works only when `namespaceIsolation` is set to true. When `globalNamespaces` is unset, it is implied that `default` will still be allowed globally.

cc: @rohan47

Fixes #567 