### PR TITLE
clarify cmdAdd error

### DIFF
--- a/multus/multus.go
+++ b/multus/multus.go
@@ -49,12 +49,16 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
-var version = "master@git"
-var commit = "unknown commit"
-var date = "unknown date"
+var (
+	version = "master@git"
+	commit  = "unknown commit"
+	date    = "unknown date"
+)
 
-var pollDuration = 1000 * time.Millisecond
-var pollTimeout = 45 * time.Second
+var (
+	pollDuration = 1000 * time.Millisecond
+	pollTimeout  = 45 * time.Second
+)
 
 func printVersionString() string {
 	return fmt.Sprintf("multus-cni version:%s, commit:%s, date:%s",
@@ -608,7 +612,7 @@ func cmdAdd(args *skel.CmdArgs, exec invoke.Exec, kubeClient *k8s.ClientInfo) (c
 			result = tmpResult
 		}
 
-		//create the network status, only in case Multus as kubeconfig
+		// create the network status, only in case Multus as kubeconfig
 		if n.Kubeconfig != "" && kc != nil {
 			if !types.CheckSystemNamespaces(string(k8sArgs.K8S_POD_NAME), n.SystemNamespaces) {
 				delegateNetStatus, err := nadutils.CreateNetworkStatus(tmpResult, delegate.Name, delegate.MasterPlugin)
@@ -621,11 +625,14 @@ func cmdAdd(args *skel.CmdArgs, exec invoke.Exec, kubeClient *k8s.ClientInfo) (c
 		}
 	}
 
-	//set the network status annotation in apiserver, only in case Multus as kubeconfig
+	// set the network status annotation in apiserver, only in case Multus as kubeconfig
 	if n.Kubeconfig != "" && kc != nil {
 		if !types.CheckSystemNamespaces(string(k8sArgs.K8S_POD_NAME), n.SystemNamespaces) {
 			err = k8s.SetNetworkStatus(kubeClient, k8sArgs, netStatus, n)
 			if err != nil {
+				if strings.Contains(err.Error(), "failed to query the pod") {
+					return nil, cmdErr(k8sArgs, "error setting the networks status, pod was already deleted: %v", err)
+				}
 				return nil, cmdErr(k8sArgs, "error setting the networks status: %v", err)
 			}
 		}
@@ -803,7 +810,6 @@ func cmdDel(args *skel.CmdArgs, exec invoke.Exec, kubeClient *k8s.ClientInfo) er
 }
 
 func main() {
-
 	// Init command line flags to clear vendored packages' one, especially in init()
 	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
 


### PR DESCRIPTION
it can happen that a CNI Add operation is canceled because the
runtime sends a CNI Del too fast, so the pod was already deleted
when multus try to set the network status annotations.

Since multus is an executable and can not persist state, it can't
track the CNI requests that are done in parallel, but it can
assume that, if it was able to get the pod from the API, and in a
subsequent request the pod no longer exists, it is because it was
deleted.

Signed-off-by: Antonio Ojea <aojea@redhat.com>

An example of the error is here:
https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/cri-o_cri-o/4361/pull-ci-cri-o-cri-o-master-e2e-gcp/1329161665811320832


> ns/e2e-deployment-9487 pod/webserver-57656d96fb-4r4l5 node/ci-op-qpgcdqxr-3caf3-zl879-worker-b-lx77w - 5.31 seconds after deletion - reason/FailedCreatePodSandBox Failed to create pod sandbox: rpc error: code = Unknown desc = failed to create pod network sandbox k8s_webserver-57656d96fb-4r4l5_e2e-deployment-9487_593a7762-4db3-439e-80ce-6d12e8da10b2_0(0c4fe84f2bf6ccd3c3329c4985d0be099306f5fd13ebca0b4060dc1d75bf559d): Multus: [e2e-deployment-9487/webserver-57656d96fb-4r4l5]: error setting the networks status: SetNetworkStatus: failed to query the pod webserver-57656d96fb-4r4l5 in out of cluster comm: pods "webserver-57656d96fb-4r4l5" not 