### PR TITLE
Cleanup multus config file 00-multus.conf when deleting daemonset

### DIFF
--- a/images/entrypoint.sh
+++ b/images/entrypoint.sh
@@ -380,6 +380,11 @@ generateMultusConf
 
 # ---------------------- end Generate "00-multus.conf".
 
+# remove "00-multus.conf" on close.
+if [ "$MULTUS_CONF_FILE" == "auto" ]; then
+  trap "rm -f $CNI_CONF_DIR/00-multus.conf" EXIT
+fi
+
 # Enter either sleep loop, or watch loop...
 if [ "$MULTUS_CLEANUP_CONFIG_ON_EXIT" == true ]; then
   log "Entering watch loop..."


### PR DESCRIPTION
When multus daemonset is deleted the auto generated config file
00-multus.conf is left, when new pod created and uses that conf
cni file, it will fail because multus roles are removed

This patch cleanup multus conf file 00-multus to allow using previous
primary cni config file

Fixes #592 