### PR TITLE
Fix entrypoint fail to read capabilities in non chain plugin config

### DIFF
--- a/images/entrypoint.sh
+++ b/images/entrypoint.sh
@@ -317,8 +317,11 @@ if [ "$MULTUS_CONF_FILE" == "auto" ]; then
 import json,sys
 conf = json.load(sys.stdin)
 capabilities = {}
-for capa in [p['capabilities'] for p in conf['plugins'] if 'capabilities' in p]:
-    capabilities.update({capability:enabled for (capability,enabled) in capa.items() if enabled})
+if 'plugins' in conf:
+    for capa in [p['capabilities'] for p in conf['plugins'] if 'capabilities' in p]:
+        capabilities.update({capability:enabled for (capability,enabled) in capa.items() if enabled})
+elif 'capabilities' in conf:
+    capabilities.update({capability:enabled for (capability,enabled) in conf['capabilities'] if enabled})
 if len(capabilities) > 0:
     print("""\"capabilities\": """ + json.dumps(capabilities) + ",")
 else:


### PR DESCRIPTION
entrypoint script fails with error when try reading capabilities in
non chain plugin config file when using "--multus-conf-file=auto"

Fixes #594 