### PR TITLE
Pods in daemonset should have grace period reduced.

### DIFF
--- a/images/multus-daemonset-crio.yml
+++ b/images/multus-daemonset-crio.yml
@@ -199,6 +199,7 @@ spec:
           mountPath: /host/usr/libexec/cni
         - name: multus-cfg
           mountPath: /tmp/multus-conf
+      terminationGracePeriodSeconds: 10
       volumes:
         - name: run
           hostPath:

--- a/images/multus-daemonset.yml
+++ b/images/multus-daemonset.yml
@@ -192,6 +192,7 @@ spec:
           mountPath: /host/opt/cni/bin
         - name: multus-cfg
           mountPath: /tmp/multus-conf
+      terminationGracePeriodSeconds: 10
       volumes:
         - name: cni
           hostPath:
@@ -259,6 +260,7 @@ spec:
           mountPath: /host/opt/cni/bin
         - name: multus-cfg
           mountPath: /tmp/multus-conf
+      terminationGracePeriodSeconds: 10
       volumes:
         - name: cni
           hostPath:
@@ -325,6 +327,7 @@ spec:
           mountPath: /host/opt/cni/bin
         - name: multus-cfg
           mountPath: /tmp/multus-conf
+      terminationGracePeriodSeconds: 10
       volumes:
         - name: cni
           hostPath:


### PR DESCRIPTION
Otherwise, it can take a long time for the daemonset to stop, and there's no real reason it needs to hang out for a long time.