### PR TITLE
Add validateK8sApi flag

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,6 +18,7 @@ Following is the example of multus config file, in `/etc/cni/net.d/`.
     },    
     "readinessindicatorfile": "",
     "namespaceIsolation": false,
+    "validateK8sApi": true,
 "Note1":"NOTE: you can set clusterNetwork+defaultNetworks OR delegates!!",
     "clusterNetwork": "defaultCRD",
     "defaultNetworks": ["sidecarCRD", "flannel"],
@@ -45,6 +46,7 @@ Following is the example of multus config file, in `/etc/cni/net.d/`.
 * `namespaceIsolation` (boolean, optional): Enables a security feature where pods are only allowed to access `NetworkAttachmentDefinitions` in the namespace where the pod resides. Defaults to false.
 * `capabilities` ({}list, optional): [capabilities](https://github.com/containernetworking/cni/blob/master/CONVENTIONS.md#dynamic-plugin-specific-fields-capabilities--runtime-configuration) supported by at least one of the delegates. (NOTE: Multus only supports portMappings capability for now). See the [example](https://github.com/intel/multus-cni/blob/master/examples/multus-ptp-portmap.conf).
 * `readinessindicatorfile`: The path to a file whose existance denotes that the default network is ready
+* `validateK8sApi`: (boolean, optional): Validates multus can reach kubernetes apiserver
 
 User should chose following parameters combination (`clusterNetwork`+`defaultNetworks` or `delegates`):
 

--- a/images/entrypoint.sh
+++ b/images/entrypoint.sh
@@ -22,6 +22,7 @@ RESTART_CRIO=false
 CRIO_RESTARTED_ONCE=false
 RENAME_SOURCE_CONFIG_FILE=false
 SKIP_BINARY_COPY=false
+VALIDATE_K8S_API=false
 
 # Give help text for parameters.
 function usage()
@@ -53,6 +54,7 @@ function usage()
     echo -e "\t--readiness-indicator-file=$MULTUS_READINESS_INDICATOR_FILE (used only with --multus-conf-file=auto)"
     echo -e "\t--additional-bin-dir=$ADDITIONAL_BIN_DIR (adds binDir option to configuration, used only with --multus-conf-file=auto)"
     echo -e "\t--restart-crio=false (restarts CRIO after config file is generated)"
+    echo -e "\t--validate-k8s-api=$VALIDATE_K8S_API (validates multus can reach kubernetes apiserver)"
 }
 
 function log()
@@ -132,6 +134,9 @@ while [ "$1" != "" ]; do
             ;;
         --readiness-indicator-file)
             MULTUS_READINESS_INDICATOR_FILE=$VALUE
+            ;;
+        --validate-k8s-api)
+            VALIDATE_K8S_API=$VALUE
             ;;
         *)
             warn "unknown parameter \"$PARAM\""
@@ -335,6 +340,7 @@ EOF
 
       MASTER_PLUGIN_LOCATION=$MULTUS_AUTOCONF_DIR/$MASTER_PLUGIN
       MASTER_PLUGIN_JSON="$(cat $MASTER_PLUGIN_LOCATION)"
+      VALIDATE_K8S_API_STRING="\"validateK8sApi\": $VALIDATE_K8S_API,"
       log "Using $MASTER_PLUGIN_LOCATION as a source to generate the Multus configuration"
       CONF=$(cat <<-EOF
         {
@@ -347,6 +353,7 @@ EOF
           $LOG_LEVEL_STRING
           $LOG_FILE_STRING
           $ADDITIONAL_BIN_DIR_STRING
+          $VALIDATE_K8S_API_STRING
           $READINESS_INDICATOR_FILE_STRING
           "kubeconfig": "$MULTUS_KUBECONFIG_FILE_HOST",
           "delegates": [

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -50,6 +50,7 @@ type NetConf struct {
 	NamespaceIsolation       bool     `json:"namespaceIsolation"`
 	RawNonIsolatedNamespaces string   `json:"globalNamespaces"`
 	NonIsolatedNamespaces    []string `json:"-"`
+	ValidateK8sApi           bool     `json:"validateK8sApi"`
 
 	// Option to set system namespaces (to avoid to add defaultNetworks)
 	SystemNamespaces []string `json:"systemNamespaces"`


### PR DESCRIPTION
When this flag is set it validates that multus can communicate with Kubernetes API and if failed to communicate it fails the cni. If set to false then skip failure when multus can't get pod data