### PR TITLE
Add s390x support

### DIFF
--- a/.github/workflows/docker-build-push-master.yml
+++ b/.github/workflows/docker-build-push-master.yml
@@ -25,6 +25,9 @@ jobs:
   
       - name: Build latest-arm64v8
         run: docker build -t ${REPOSITORY}:latest-arm64v8 -f deployments/Dockerfile.arm64 .
+
+      - name: Build latest-s390x
+        run: docker build -t ${REPOSITORY}:latest-s390x -f deployments/Dockerfile.s390x .
   
       - name: Build latest-origin
         run: docker build -t ${REPOSITORY}:latest-origin -f deployments/Dockerfile.openshift .
@@ -34,6 +37,7 @@ jobs:
           docker tag ${REPOSITORY}:latest-amd64 ${REPOSITORY}:snapshot-amd64
           docker tag ${REPOSITORY}:latest-ppc64le ${REPOSITORY}:snapshot-ppc64le
           docker tag ${REPOSITORY}:latest-arm64v8 ${REPOSITORY}:snapshot-arm64v8
+          docker tag ${REPOSITORY}:latest-s390x ${REPOSITORY}:snapshot-s390x
 
       - name: Login to registry
         if: github.repository == 'intel/multus-cni'
@@ -45,20 +49,24 @@ jobs:
           docker push ${REPOSITORY}:latest-amd64
           docker push ${REPOSITORY}:latest-ppc64le
           docker push ${REPOSITORY}:latest-arm64v8
+          docker push ${REPOSITORY}:latest-s390x
           docker push ${REPOSITORY}:snapshot-amd64
           docker push ${REPOSITORY}:snapshot-ppc64le
           docker push ${REPOSITORY}:snapshot-arm64v8
+          docker push ${REPOSITORY}:snapshot-s390x
   
       - name: Create manifest for multi-arch images
         if: github.repository == 'intel/multus-cni'
         run: |
-          docker manifest create ${REPOSITORY}:snapshot ${REPOSITORY}:snapshot-amd64 ${REPOSITORY}:snapshot-ppc64le ${REPOSITORY}:snapshot-arm64v8
+          docker manifest create ${REPOSITORY}:snapshot ${REPOSITORY}:snapshot-amd64 ${REPOSITORY}:snapshot-ppc64le ${REPOSITORY}:snapshot-arm64v8 ${REPOSITORY}:snapshot-s390x
           docker manifest annotate ${REPOSITORY}:snapshot ${REPOSITORY}:snapshot-amd64 --arch amd64
           docker manifest annotate ${REPOSITORY}:snapshot ${REPOSITORY}:snapshot-ppc64le --arch ppc64le
           docker manifest annotate ${REPOSITORY}:snapshot ${REPOSITORY}:snapshot-arm64v8 --arch arm64
+          docker manifest annotate ${REPOSITORY}:snapshot ${REPOSITORY}:snapshot-s390x --arch s390x
           docker manifest push ${REPOSITORY}:snapshot
-          docker manifest create ${REPOSITORY}:latest ${REPOSITORY}:latest-amd64 ${REPOSITORY}:latest-ppc64le ${REPOSITORY}:latest-arm64v8
+          docker manifest create ${REPOSITORY}:latest ${REPOSITORY}:latest-amd64 ${REPOSITORY}:latest-ppc64le ${REPOSITORY}:latest-arm64v8 ${REPOSITORY}:latest-s390x
           docker manifest annotate ${REPOSITORY}:latest ${REPOSITORY}:latest-amd64 --arch amd64
           docker manifest annotate ${REPOSITORY}:latest ${REPOSITORY}:latest-ppc64le --arch ppc64le
           docker manifest annotate ${REPOSITORY}:latest ${REPOSITORY}:latest-arm64v8 --arch arm64
+          docker manifest annotate ${REPOSITORY}:latest ${REPOSITORY}:latest-s390x --arch s390x
           docker manifest push ${REPOSITORY}:latest

--- a/.github/workflows/docker-build-push-release.yml
+++ b/.github/workflows/docker-build-push-release.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Build latest-arm64v8
         run: docker build -t ${REPOSITORY}:latest-arm64v8 -f deployments/Dockerfile.arm64 .
   
+      - name: Build latest-s390x
+        run: docker build -t ${REPOSITORY}:latest-s390x -f deployments/Dockerfile.s390x .
+
       - name: Build latest-origin
         run: docker build -t ${REPOSITORY}:latest-origin -f deployments/Dockerfile.openshift .
   
@@ -34,9 +37,11 @@ jobs:
           docker tag ${REPOSITORY}:latest-amd64 ${REPOSITORY}:stable-amd64
           docker tag ${REPOSITORY}:latest-ppc64le ${REPOSITORY}:stable-ppc64le
           docker tag ${REPOSITORY}:latest-arm64v8 ${REPOSITORY}:stable-arm64v8
+          docker tag ${REPOSITORY}:latest-s390x ${REPOSITORY}:stable-s390x
           docker tag ${REPOSITORY}:latest-amd64 ${REPOSITORY}:${GITHUB_REF##*/}-amd64
           docker tag ${REPOSITORY}:latest-ppc64le ${REPOSITORY}:${GITHUB_REF##*/}-ppc64le
           docker tag ${REPOSITORY}:latest-arm64v8 ${REPOSITORY}:${GITHUB_REF##*/}-arm64v8
+          docker tag ${REPOSITORY}:latest-s390x ${REPOSITORY}:${GITHUB_REF##*/}-s390x
   
       - name: Login to registry
         if: github.repository == 'intel/multus-cni'
@@ -48,28 +53,34 @@ jobs:
           docker push ${REPOSITORY}:latest-amd64
           docker push ${REPOSITORY}:latest-ppc64le
           docker push ${REPOSITORY}:latest-arm64v8
+          docker push ${REPOSITORY}:latest-s390x
           docker push ${REPOSITORY}:stable-amd64
           docker push ${REPOSITORY}:stable-ppc64le
           docker push ${REPOSITORY}:stable-arm64v8
+          docker push ${REPOSITORY}:stable-s390x
           docker push ${REPOSITORY}:${GITHUB_REF##*/}-amd64
           docker push ${REPOSITORY}:${GITHUB_REF##*/}-ppc64le
           docker push ${REPOSITORY}:${GITHUB_REF##*/}-arm64v8
+          docker push ${REPOSITORY}:${GITHUB_REF##*/}-s390x
   
       - name: Create manifest for multi-arch images
         if: github.repository == 'intel/multus-cni'
         run: |
-          docker manifest create ${REPOSITORY}:stable ${REPOSITORY}:stable-amd64 ${REPOSITORY}:stable-ppc64le ${REPOSITORY}:stable-arm64v8
+          docker manifest create ${REPOSITORY}:stable ${REPOSITORY}:stable-amd64 ${REPOSITORY}:stable-ppc64le ${REPOSITORY}:stable-arm64v8 ${REPOSITORY}:stable-s390x
           docker manifest annotate ${REPOSITORY}:stable ${REPOSITORY}:stable-amd64 --arch amd64
           docker manifest annotate ${REPOSITORY}:stable ${REPOSITORY}:stable-ppc64le --arch ppc64le
           docker manifest annotate ${REPOSITORY}:stable ${REPOSITORY}:stable-arm64v8 --arch arm64
+          docker manifest annotate ${REPOSITORY}:stable ${REPOSITORY}:stable-s390x --arch s390x
           docker manifest push ${REPOSITORY}:stable
-          docker manifest create ${REPOSITORY}:latest ${REPOSITORY}:latest-amd64 ${REPOSITORY}:latest-ppc64le ${REPOSITORY}:latest-arm64v8
+          docker manifest create ${REPOSITORY}:latest ${REPOSITORY}:latest-amd64 ${REPOSITORY}:latest-ppc64le ${REPOSITORY}:latest-arm64v8 ${REPOSITORY}:latest-s390x
           docker manifest annotate ${REPOSITORY}:latest ${REPOSITORY}:latest-amd64 --arch amd64
           docker manifest annotate ${REPOSITORY}:latest ${REPOSITORY}:latest-ppc64le --arch ppc64le
           docker manifest annotate ${REPOSITORY}:latest ${REPOSITORY}:latest-arm64v8 --arch arm64
+          docker manifest annotate ${REPOSITORY}:latest ${REPOSITORY}:latest-s390x --arch s390x
           docker manifest push ${REPOSITORY}:latest
-          docker manifest create ${REPOSITORY}:${GITHUB_REF##*/} ${REPOSITORY}:${GITHUB_REF##*/}-amd64 ${REPOSITORY}:${GITHUB_REF##*/}-ppc64le ${REPOSITORY}:${GITHUB_REF##*/}-arm64v8
+          docker manifest create ${REPOSITORY}:${GITHUB_REF##*/} ${REPOSITORY}:${GITHUB_REF##*/}-amd64 ${REPOSITORY}:${GITHUB_REF##*/}-ppc64le ${REPOSITORY}:${GITHUB_REF##*/}-arm64v8 ${REPOSITORY}:${GITHUB_REF##*/}-s390x
           docker manifest annotate ${REPOSITORY}:${GITHUB_REF##*/} ${REPOSITORY}:${GITHUB_REF##*/}-amd64 --arch amd64
           docker manifest annotate ${REPOSITORY}:${GITHUB_REF##*/} ${REPOSITORY}:${GITHUB_REF##*/}-ppc64le --arch ppc64le
           docker manifest annotate ${REPOSITORY}:${GITHUB_REF##*/} ${REPOSITORY}:${GITHUB_REF##*/}-arm64v8 --arch arm64
+          docker manifest annotate ${REPOSITORY}:${GITHUB_REF##*/} ${REPOSITORY}:${GITHUB_REF##*/}-s390x --arch s390x
           docker manifest push ${REPOSITORY}:${GITHUB_REF##*/}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -17,6 +17,9 @@ jobs:
   
       - name: Build latest-ppc64le
         run: docker build -t ${REPOSITORY}:latest-ppc64le -f deployments/Dockerfile.ppc64le .
+
+      - name: Build latest-s390x
+        run: docker build -t ${REPOSITORY}:latest-s390x -f deployments/Dockerfile.s390x .
   
       - name: Build latest-origin
         run: docker build -t ${REPOSITORY}:latest-origin -f deployments/Dockerfile.openshift .

--- a/.github/workflows/go-build-s390x.yml
+++ b/.github/workflows/go-build-s390x.yml
@@ -1,0 +1,25 @@
+name: Go-build-s390x
+on: [push, pull_request]
+jobs:
+
+  build:
+    name: Build and test
+    runs-on: ubuntu-latest
+    if: >
+      (( github.event.pull_request.head.repo.owner.login != github.event.pull_request.base.repo.owner.login ) &&
+        github.event_name == 'pull_request' ) || (github.event_name == 'push' && github.event.commits != '[]' )
+    env:
+      GO111MODULE: on
+      TARGET: s390x
+    steps:
+      - name: Set up Go 1.13
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.13
+        id: go
+  
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+  
+      - name: Build
+        run: GOARCH="${TARGET}" ./hack/build-go.sh

--- a/deployments/Dockerfile.s390x
+++ b/deployments/Dockerfile.s390x
@@ -1,0 +1,19 @@
+# This Dockerfile is used to build the image available on DockerHub
+FROM golang:1.13 as build
+
+# Add everything
+ADD . /usr/src/multus-cni
+
+ENV GOARCH "s390x"
+ENV GOOS "linux"
+
+RUN  cd /usr/src/multus-cni && \
+     ./hack/build-go.sh
+
+# build s390x container
+FROM s390x/python:3-slim
+COPY --from=build /usr/src/multus-cni /usr/src/multus-cni
+WORKDIR /
+ADD ./images/entrypoint.sh /
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/images/entrypoint.sh
+++ b/images/entrypoint.sh
@@ -77,6 +77,10 @@ function warn()
     log "WARN: {$1}"
 }
 
+if ! type python3 &> /dev/null; then
+	alias python=python3
+fi
+
 # Parse parameters given as arguments to this script.
 while [ "$1" != "" ]; do
     PARAM=`echo $1 | awk -F= '{print $1}'`
@@ -314,7 +318,7 @@ if [ "$MULTUS_CONF_FILE" == "auto" ]; then
 
       if [ "$OVERRIDE_NETWORK_NAME" == "true" ]; then
         MASTER_PLUGIN_NET_NAME="$(cat $MULTUS_AUTOCONF_DIR/$MASTER_PLUGIN | \
-            python -c 'import json,sys;print json.load(sys.stdin)["name"]')"
+            python -c 'import json,sys;print(json.load(sys.stdin)["name"])')"
       else
         MASTER_PLUGIN_NET_NAME="multus-cni-network"
       fi

--- a/images/multus-daemonset-crio.yml
+++ b/images/multus-daemonset-crio.yml
@@ -356,3 +356,73 @@ spec:
             items:
             - key: cni-conf.json
               path: 70-multus.conf
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kube-multus-ds-s390x
+  namespace: kube-system
+  labels:
+    tier: node
+    app: multus
+    name: multus
+spec:
+  selector:
+    matchLabels:
+      name: multus
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        tier: node
+        app: multus
+        name: multus
+    spec:
+      hostNetwork: true
+      nodeSelector:
+        kubernetes.io/arch: s390x
+      tolerations:
+      - operator: Exists
+        effect: NoSchedule
+      serviceAccountName: multus
+      containers:
+      - name: kube-multus
+        # crio support requires multus:latest for now. support 3.3 or later.
+        image: docker.io/nfvpe/multus:stable-s390x
+        command: ["/entrypoint.sh"]
+        args:
+        - "--cni-version=0.3.1"
+        - "--cni-bin-dir=/host/usr/libexec/cni"
+        - "--multus-conf-file=auto"
+        - "--restart-crio=true"
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "90Mi"
+          limits:
+            cpu: "100m"
+            memory: "90Mi"
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: cni
+          mountPath: /host/etc/cni/net.d
+        - name: cnibin
+          mountPath: /host/usr/libexec/cni
+        - name: multus-cfg
+          mountPath: /tmp/multus-conf
+      terminationGracePeriodSeconds: 10
+      volumes:
+        - name: cni
+          hostPath:
+            path: /etc/cni/net.d
+        - name: cnibin
+          hostPath:
+            path: /usr/libexec/cni
+        - name: multus-cfg
+          configMap:
+            name: multus-cni-config
+            items:
+            - key: cni-conf.json
+              path: 70-multus.conf

--- a/images/multus-daemonset.yml
+++ b/images/multus-daemonset.yml
@@ -341,3 +341,70 @@ spec:
             items:
             - key: cni-conf.json
               path: 70-multus.conf
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kube-multus-ds-s390x
+  namespace: kube-system
+  labels:
+    tier: node
+    app: multus
+    name: multus
+spec:
+  selector:
+    matchLabels:
+      name: multus
+  updateStrategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        tier: node
+        app: multus
+        name: multus
+    spec:
+      hostNetwork: true
+      nodeSelector:
+        kubernetes.io/arch: s390x
+      tolerations:
+      - operator: Exists
+        effect: NoSchedule
+      serviceAccountName: multus
+      containers:
+      - name: kube-multus
+        image: docker.io/nfvpe/multus:stable-s390x
+        command: ["/entrypoint.sh"]
+        args:
+        - "--multus-conf-file=auto"
+        - "--cni-version=0.3.1"
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "90Mi"
+          limits:
+            cpu: "100m"
+            memory: "90Mi"
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: cni
+          mountPath: /host/etc/cni/net.d
+        - name: cnibin
+          mountPath: /host/opt/cni/bin
+        - name: multus-cfg
+          mountPath: /tmp/multus-conf
+      terminationGracePeriodSeconds: 10
+      volumes:
+        - name: cni
+          hostPath:
+            path: /etc/cni/net.d
+        - name: cnibin
+          hostPath:
+            path: /opt/cni/bin
+        - name: multus-cfg
+          configMap:
+            name: multus-cni-config
+            items:
+            - key: cni-conf.json
+              path: 70-multus.conf


### PR DESCRIPTION
This PR updates the GitHub Actions workflows to build multus
container images for the IBM Z architecture (s390x), and also
adds daemonsets for s390x nodes.

entrypoint.sh uses python3 when it is available, since centos images
are not available for s390x, and python2 is not installed by default
on debian-based images.

Signed-off-by: Yohei Ueda <yohei@jp.ibm.com>