### PR TITLE
Fix invite to NPWG slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,4 +48,4 @@ This will configure your systems to be ready to use Multus CNI, but, to get star
 
 ## Contact Us
 
-For any questions about Multus CNI, feel free to ask a question in #general in the [NPWG Slack](https://npwg-team.slack.com/), or open up a GitHub issue.
+For any questions about Multus CNI, feel free to ask a question in #general in the [NPWG Slack](https://npwg-team.slack.com/), or open up a GitHub issue. Request an invite to NPWG slack [here](https://intel-corp.herokuapp.com/).


### PR DESCRIPTION
Re-adding NPWG slack invite mechanism.

Signed-off-by: Kennelly, Martin <martin.kennelly@intel.com>

I misunderstood slacks invite mechanism for non-Intel users. Non-Intel users require invite it seems. Re-adding invite mechanism. I attempted to change URL of invite mechanism but failed. Slack only grands auto invite rights to enterprise workspaces. See here https://github.com/outsideris/slack-invite-automation/issues/146
Currently, the intel-corp.heroku.com app relies on legacy token mechanism to accomplish this. This will fail in the future when legacy tokens are deprecated. I think this should be discussed at NPWG level but in the mean time, I propose re-adding auto invite mechanism. Thanks @s1061123  for highlighting this!